### PR TITLE
Add plaintext rendering for footnotes.

### DIFF
--- a/src/plaintext.c
+++ b/src/plaintext.c
@@ -191,6 +191,28 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
   case CMARK_NODE_IMAGE:
     break;
 
+  case CMARK_NODE_FOOTNOTE_REFERENCE:
+    if (entering) {
+      LIT("[^");
+      OUT(cmark_chunk_to_cstr(renderer->mem, &node->as.literal), false, LITERAL);
+      LIT("]");
+    }
+    break;
+
+  case CMARK_NODE_FOOTNOTE_DEFINITION:
+    if (entering) {
+      renderer->footnote_ix += 1;
+      LIT("[^");
+      char n[32];
+      snprintf(n, sizeof(n), "%d", renderer->footnote_ix);
+      OUT(n, false, LITERAL);
+      LIT("]: ");
+
+      cmark_strbuf_puts(renderer->prefix, "    ");
+    } else {
+      cmark_strbuf_truncate(renderer->prefix, renderer->prefix->size - 4);
+    }
+    break;
   default:
     assert(false);
     break;


### PR DESCRIPTION
Otherwise, it crashes in debug mode. Reproduction:

```
make debug
build/src/cmark-gfm --to plaintext --extension footnotes <<EOF
Paragraph with [^1] footnote.

[^1]:this is the footnote
EOF
aborted
```

After the change, it is:

```
make debug
build/src/cmark-gfm --to plaintext --extension footnotes <<EOF
Paragraph with [^1] footnote.

[^1]:this is the footnote
EOF
Paragraph with [^1] footnote.

[^1]: this is the footnote
```