### PR TITLE
Remove options mask from fuzzing harness

### DIFF
--- a/test/cmark-fuzz.c
+++ b/test/cmark-fuzz.c
@@ -27,24 +27,6 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     /* The beginning of `data` is treated as fuzzer configuration */
     memcpy(&fuzz_config, data, sizeof(fuzz_config));
 
-    /* Mask off valid option bits */
-    fuzz_config.options &= (
-      CMARK_OPT_SOURCEPOS |
-      CMARK_OPT_HARDBREAKS |
-      CMARK_OPT_NOBREAKS |
-      CMARK_OPT_NORMALIZE |
-      CMARK_OPT_VALIDATE_UTF8 |
-      CMARK_OPT_SMART |
-      /* GFM specific options */
-      CMARK_OPT_GITHUB_PRE_LANG |
-      CMARK_OPT_LIBERAL_HTML_TAG |
-      CMARK_OPT_FOOTNOTES |
-      CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE |
-      CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES |
-      CMARK_OPT_FULL_INFO_STRING |
-      CMARK_OPT_UNSAFE
-    );
-
     /* Remainder of input is the markdown */
     const char *markdown = (const char *)(data + sizeof(fuzz_config));
     const size_t markdown_size = size - sizeof(fuzz_config);


### PR DESCRIPTION
A followup to #127 where @gregose pointed out that the option-mask is prone to bit-rot.

The option mask needs to be kept up to date when new options are added, which
is error-prone. Just remove the masking logic as `cmark_parser_new` does not
validate the options bitmask anyway.