### PR TITLE
Adjustments to how the tasklist generation occurs

### DIFF
--- a/extensions/cmark-gfm-core-extensions.h
+++ b/extensions/cmark-gfm-core-extensions.h
@@ -21,6 +21,9 @@ uint8_t *cmark_gfm_extensions_get_table_alignments(cmark_node *node);
 CMARK_GFM_EXTENSIONS_EXPORT
 int cmark_gfm_extensions_get_table_row_is_header(cmark_node *node);
 
+CMARK_GFM_EXTENSIONS_EXPORT
+char *cmark_gfm_extensions_get_tasklist_state(cmark_node *node);
+
 #ifdef __cplusplus
 }
 #endif

--- a/extensions/tasklist.c
+++ b/extensions/tasklist.c
@@ -90,13 +90,13 @@ static void commonmark_render(cmark_syntax_extension *extension,
   if (entering) {
     renderer->cr(renderer);
     if (node->as.opaque == CMARK_TASKLIST_CHECKED) {
-      renderer->out(renderer, node, "  - [x] ", false, LITERAL);
+      renderer->out(renderer, node, "- [x] ", false, LITERAL);
     } else {
-      renderer->out(renderer, node, "  - [ ] ", false, LITERAL);
+      renderer->out(renderer, node, "- [ ] ", false, LITERAL);
     }
-    cmark_strbuf_puts(renderer->prefix, "    ");
+    cmark_strbuf_puts(renderer->prefix, "  ");
   } else {
-    cmark_strbuf_truncate(renderer->prefix, renderer->prefix->size - 4);
+    cmark_strbuf_truncate(renderer->prefix, renderer->prefix->size - 2);
     renderer->cr(renderer);
   }
 }
@@ -107,13 +107,13 @@ static void html_render(cmark_syntax_extension *extension,
   bool entering = (ev_type == CMARK_EVENT_ENTER);
   if (entering) {
     cmark_html_render_cr(renderer->html);
-    cmark_strbuf_puts(renderer->html, "<li class=\"task-list-item\"");
+    cmark_strbuf_puts(renderer->html, "<li");
     cmark_html_render_sourcepos(node, renderer->html, options);
     cmark_strbuf_putc(renderer->html, '>');
     if (node->as.opaque == CMARK_TASKLIST_CHECKED) {
-      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" checked=\"\" disabled=\"\" />");
+      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" checked=\"\" disabled=\"\" /> ");
     } else {
-      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" disabled=\"\" />");
+      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" disabled=\"\" /> ");
     }
   } else {
     cmark_strbuf_puts(renderer->html, "</li>\n");

--- a/extensions/tasklist.c
+++ b/extensions/tasklist.c
@@ -14,10 +14,10 @@ static const char *get_type_string(cmark_syntax_extension *extension, cmark_node
 }
 
 char *cmark_gfm_extensions_get_tasklist_state(cmark_node *node) {
-  if (!node || (node->as.opaque != CMARK_TASKLIST_CHECKED && node->as.opaque != CMARK_TASKLIST_NOCHECKED))
+  if (!node || ((int)node->as.opaque != CMARK_TASKLIST_CHECKED && (int)node->as.opaque != CMARK_TASKLIST_NOCHECKED))
     return 0;
 
-  if (node->as.opaque != CMARK_TASKLIST_CHECKED) {
+  if ((int)node->as.opaque != CMARK_TASKLIST_CHECKED) {
     return "checked";
   }
   else {
@@ -75,9 +75,9 @@ static cmark_node *open_tasklist_item(cmark_syntax_extension *self,
   cmark_parser_advance_offset(parser, (char *)input, 3, false);
 
   if (strstr((char*)input, "[x]")) {
-    parent_container->as.opaque = CMARK_TASKLIST_CHECKED;
+    parent_container->as.opaque = (void *)CMARK_TASKLIST_CHECKED;
   } else {
-    parent_container->as.opaque = CMARK_TASKLIST_NOCHECKED;
+    parent_container->as.opaque = (void *)CMARK_TASKLIST_NOCHECKED;
   }
 
   return NULL;
@@ -89,7 +89,7 @@ static void commonmark_render(cmark_syntax_extension *extension,
   bool entering = (ev_type == CMARK_EVENT_ENTER);
   if (entering) {
     renderer->cr(renderer);
-    if (node->as.opaque == CMARK_TASKLIST_CHECKED) {
+    if ((int)node->as.opaque == CMARK_TASKLIST_CHECKED) {
       renderer->out(renderer, node, "- [x] ", false, LITERAL);
     } else {
       renderer->out(renderer, node, "- [ ] ", false, LITERAL);
@@ -110,7 +110,7 @@ static void html_render(cmark_syntax_extension *extension,
     cmark_strbuf_puts(renderer->html, "<li");
     cmark_html_render_sourcepos(node, renderer->html, options);
     cmark_strbuf_putc(renderer->html, '>');
-    if (node->as.opaque == CMARK_TASKLIST_CHECKED) {
+    if ((int)node->as.opaque == CMARK_TASKLIST_CHECKED) {
       cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" checked=\"\" disabled=\"\" /> ");
     } else {
       cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" disabled=\"\" /> ");

--- a/extensions/tasklist.c
+++ b/extensions/tasklist.c
@@ -13,6 +13,18 @@ static const char *get_type_string(cmark_syntax_extension *extension, cmark_node
   return "tasklist";
 }
 
+char *cmark_gfm_extensions_get_tasklist_state(cmark_node *node) {
+  if (!node || (node->as.opaque != CMARK_TASKLIST_CHECKED && node->as.opaque != CMARK_TASKLIST_NOCHECKED))
+    return 0;
+
+  if (node->as.opaque != CMARK_TASKLIST_CHECKED) {
+    return "checked";
+  }
+  else {
+    return "unchecked";
+  }
+}
+
 static bool parse_node_item_prefix(cmark_parser *parser, const char *input,
                                    cmark_node *container) {
   bool res = false;
@@ -62,13 +74,11 @@ static cmark_node *open_tasklist_item(cmark_syntax_extension *self,
   cmark_node_set_syntax_extension(parent_container, self);
   cmark_parser_advance_offset(parser, (char *)input, 3, false);
 
-  long userdata;
   if (strstr((char*)input, "[x]")) {
-    userdata = CMARK_TASKLIST_CHECKED;
+    parent_container->as.opaque = CMARK_TASKLIST_CHECKED;
   } else {
-    userdata = CMARK_TASKLIST_NOCHECKED;
+    parent_container->as.opaque = CMARK_TASKLIST_NOCHECKED;
   }
-  cmark_node_set_user_data(parent_container, (void*)userdata);
 
   return NULL;
 }
@@ -79,8 +89,7 @@ static void commonmark_render(cmark_syntax_extension *extension,
   bool entering = (ev_type == CMARK_EVENT_ENTER);
   if (entering) {
     renderer->cr(renderer);
-    long userdata = (long)cmark_node_get_user_data(node);
-    if (userdata == CMARK_TASKLIST_CHECKED) {
+    if (node->as.opaque == CMARK_TASKLIST_CHECKED) {
       renderer->out(renderer, node, "  - [x] ", false, LITERAL);
     } else {
       renderer->out(renderer, node, "  - [ ] ", false, LITERAL);
@@ -98,14 +107,13 @@ static void html_render(cmark_syntax_extension *extension,
   bool entering = (ev_type == CMARK_EVENT_ENTER);
   if (entering) {
     cmark_html_render_cr(renderer->html);
-    cmark_strbuf_puts(renderer->html, "<li");
+    cmark_strbuf_puts(renderer->html, "<li class=\"task-list-item\"");
     cmark_html_render_sourcepos(node, renderer->html, options);
     cmark_strbuf_putc(renderer->html, '>');
-    long userdata = (long)cmark_node_get_user_data(node);
-    if (userdata == CMARK_TASKLIST_CHECKED) {
-      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" checked=\"\" disabled=\"\" /> ");
+    if (node->as.opaque == CMARK_TASKLIST_CHECKED) {
+      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" checked=\"\" disabled=\"\" />");
     } else {
-      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" disabled=\"\" /> ");
+      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" disabled=\"\" />");
     }
   } else {
     cmark_strbuf_puts(renderer->html, "</li>\n");


### PR DESCRIPTION
As discussed in https://github.com/gjtorikian/commonmarker/pull/94#issuecomment-463859127, this PR makes a few changes to how tasklists are rendered for use in client libraries that may want to override the default HTML rendering.

I implemented the suggestion [here](https://github.com/gjtorikian/commonmarker/pull/94#issuecomment-463860563) to use `opaque` as a space to store the checked/unchecked enum. I hope I've done this part correctly, I'm not entirely familiar with how opaque works. 

Also, I added `cmark_gfm_extensions_get_tasklist_state`, as there's no other way to get that information, given a tasklist node.

Finally, I noticed that there was an extraneous space space being inserted right after the checkbox. Normal `<li>` tags do not have this, so I've removed it from the string. 