### PR TITLE
Define _DEFAULT_SOURCE to get various posix/gnu glibc functions declared

### DIFF
--- a/api_test/harness.c
+++ b/api_test/harness.c
@@ -1,3 +1,4 @@
+#define _DEFAULT_SOURCE
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
fdopen, strdup and others are not declared by glibc header files
unless _DEFAULT_SOURCE is defined.

Signed-off-by: Keith Packard <keithp@keithp.com>