### PR TITLE
Add XML attribute to tasklist

### DIFF
--- a/extensions/tasklist.c
+++ b/extensions/tasklist.c
@@ -121,6 +121,15 @@ static void html_render(cmark_syntax_extension *extension,
   }
 }
 
+static const char *xml_attr(cmark_syntax_extension *extension,
+                            cmark_node *node) {
+  if ((int)node->as.opaque == CMARK_TASKLIST_CHECKED) {
+    return " completed=\"true\"";
+  } else {
+    return " completed=\"false\"";
+  }
+}
+
 cmark_syntax_extension *create_tasklist_extension(void) {
   cmark_syntax_extension *ext = cmark_syntax_extension_new("tasklist");
 
@@ -131,6 +140,7 @@ cmark_syntax_extension *create_tasklist_extension(void) {
   cmark_syntax_extension_set_commonmark_render_func(ext, commonmark_render);
   cmark_syntax_extension_set_plaintext_render_func(ext, commonmark_render);
   cmark_syntax_extension_set_html_render_func(ext, html_render);
+  cmark_syntax_extension_set_xml_attr_func(ext, xml_attr);
 
   return ext;
 }


### PR DESCRIPTION
This solves #144 for XML, but I didn't know what the appropriate stuff was for some of the other renderings (like latex or man).

I'm not positive this is the best attribute to use, but at least it doesn't lose the information as to whether the task was completed. Perhaps a different attribute name would be better, or to use the style where you don't include the attribute if the value is false? I opted for being explicit so that it's obvious to all users whether a task had been completed or not.

