### PR TITLE
Fix full reference link example

### DIFF
--- a/test/spec.txt
+++ b/test/spec.txt
@@ -8327,11 +8327,11 @@ emphasis grouping:
 
 
 ```````````````````````````````` example
-[foo *bar][ref]
+[foo *bar][ref]*
 
 [ref]: /uri
 .
-<p><a href="/uri">foo *bar</a></p>
+<p><a href="/uri">foo *bar</a>*</p>
 ````````````````````````````````
 
 


### PR DESCRIPTION
According to the introducing text, this example "illustrate[s] the precedence of link text grouping over emphasis grouping." The added * makes it look like an emphasis.