### PR TITLE
Change cmark_gfm_extensions_get_tasklist_state to cmark_gfm_extension…

### DIFF
--- a/extensions/cmark-gfm-core-extensions.h
+++ b/extensions/cmark-gfm-core-extensions.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include "cmark-gfm-extension_api.h"
 #include "cmark-gfm-extensions_export.h"
+#include "config.h"
 #include <stdint.h>
 
 CMARK_GFM_EXTENSIONS_EXPORT
@@ -22,7 +23,7 @@ CMARK_GFM_EXTENSIONS_EXPORT
 int cmark_gfm_extensions_get_table_row_is_header(cmark_node *node);
 
 CMARK_GFM_EXTENSIONS_EXPORT
-char *cmark_gfm_extensions_get_tasklist_state(cmark_node *node);
+bool cmark_gfm_extensions_tasklist_state_is_checked(cmark_node *node);
 
 #ifdef __cplusplus
 }

--- a/extensions/tasklist.c
+++ b/extensions/tasklist.c
@@ -9,19 +9,22 @@ typedef enum {
   CMARK_TASKLIST_CHECKED,
 } cmark_tasklist_type;
 
+// Local constants
+static const char *TYPE_STRING = "tasklist";
+
 static const char *get_type_string(cmark_syntax_extension *extension, cmark_node *node) {
-  return "tasklist";
+  return TYPE_STRING;
 }
 
-char *cmark_gfm_extensions_get_tasklist_state(cmark_node *node) {
-  if (!node || ((int)node->as.opaque != CMARK_TASKLIST_CHECKED && (int)node->as.opaque != CMARK_TASKLIST_NOCHECKED))
-    return 0;
+bool cmark_gfm_extensions_tasklist_state_is_checked(cmark_node *node) {
+  if (!node || !node->extension || strcmp(cmark_node_get_type_string(node), TYPE_STRING))
+    return false;
 
   if ((int)node->as.opaque == CMARK_TASKLIST_CHECKED) {
-    return "checked";
+    return true;
   }
   else {
-    return "unchecked";
+    return false;
   }
 }
 


### PR DESCRIPTION
…s_tasklist_state_is_checked

This is in response to issue #160.
This removes cmark_gfm_extensions_get_tasklist_state and adds the
new cmark_gfm_extensions_tasklist_state_is_checked.

As I said in #160, I think that the existing `cmark_gfm_extensions_get_tasklist_state` isn't very useful, so I got rid of it and replaced it with the new function.

If you disagree with removing the old function in order to maintain compatibility, let me know and I'll submit a pull request with just adding the new function.