### PR TITLE
Make "set" functions public, add "set" function for tasklist

### DIFF
--- a/extensions/cmark-gfm-core-extensions.h
+++ b/extensions/cmark-gfm-core-extensions.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include "cmark-gfm-extension_api.h"
 #include "cmark-gfm-extensions_export.h"
-#include "config.h"
+#include "config.h" // for bool
 #include <stdint.h>
 
 CMARK_GFM_EXTENSIONS_EXPORT
@@ -16,14 +16,36 @@ void cmark_gfm_core_extensions_ensure_registered(void);
 CMARK_GFM_EXTENSIONS_EXPORT
 uint16_t cmark_gfm_extensions_get_table_columns(cmark_node *node);
 
+/** Sets the number of columns for the table, returning 1 on success and 0 on error.
+ */
+CMARK_GFM_EXTENSIONS_EXPORT
+int cmark_gfm_extensions_set_table_columns(cmark_node *node, uint16_t n_columns);
+
 CMARK_GFM_EXTENSIONS_EXPORT
 uint8_t *cmark_gfm_extensions_get_table_alignments(cmark_node *node);
+
+/** Sets the alignments for the table, returning 1 on success and 0 on error.
+ */
+CMARK_GFM_EXTENSIONS_EXPORT
+int cmark_gfm_extensions_set_table_alignments(cmark_node *node, uint16_t ncols, uint8_t *alignments);
 
 CMARK_GFM_EXTENSIONS_EXPORT
 int cmark_gfm_extensions_get_table_row_is_header(cmark_node *node);
 
+/** Sets whether the node is a table header row, returning 1 on success and 0 on error.
+ */
 CMARK_GFM_EXTENSIONS_EXPORT
-bool cmark_gfm_extensions_tasklist_state_is_checked(cmark_node *node);
+int cmark_gfm_extensions_set_table_row_is_header(cmark_node *node, int is_header);
+
+CMARK_GFM_EXTENSIONS_EXPORT
+bool cmark_gfm_extensions_get_tasklist_item_checked(cmark_node *node);
+/* For backwards compatibility */
+#define cmark_gfm_extensions_tasklist_is_checked cmark_gfm_extensions_get_tasklist_item_checked
+
+/** Sets whether a tasklist item is "checked" (completed), returning 1 on success and 0 on error.
+ */
+CMARK_GFM_EXTENSIONS_EXPORT
+int cmark_gfm_extensions_set_tasklist_item_checked(cmark_node *node, bool is_checked);
 
 #ifdef __cplusplus
 }

--- a/extensions/tasklist.c
+++ b/extensions/tasklist.c
@@ -16,7 +16,24 @@ static const char *get_type_string(cmark_syntax_extension *extension, cmark_node
   return TYPE_STRING;
 }
 
-bool cmark_gfm_extensions_tasklist_state_is_checked(cmark_node *node) {
+
+// Return 1 if state was set, 0 otherwise
+int cmark_gfm_extensions_set_tasklist_item_checked(cmark_node *node, bool is_checked) {
+  // The node has to exist, and be an extension, and actually be the right type in order to get the value.
+  if (!node || !node->extension || strcmp(cmark_node_get_type_string(node), TYPE_STRING))
+    return 0;
+
+  if (is_checked) {
+    node->as.opaque = (void *)CMARK_TASKLIST_CHECKED;
+    return 1;
+  }
+  else {
+    node->as.opaque = (void *)CMARK_TASKLIST_NOCHECKED;
+    return 1;
+  }
+}
+
+bool cmark_gfm_extensions_get_tasklist_item_checked(cmark_node *node) {
   if (!node || !node->extension || strcmp(cmark_node_get_type_string(node), TYPE_STRING))
     return false;
 


### PR DESCRIPTION
Also rename "get" function for tasklist to better match others.

This addresses #159 to provide a programmatic way to manipulate extension nodes.

This code:
* makes existing table extension "set" functions **public**. It doesn't add any functions, just makes them public.
  I have _not_ tested these functions. They were already written and it looked like they were designed to be public given the names. If you would prefer, I can take them out of the header file and re-submit the pull request. It just seemed that to be better to make all manipulation functions public and then deal with bugs later.
* **adds** a new function `cmark_gfm_extensions_set_tasklist_item_checked` to modify a tasklist item node to set whether it should be denoted as checked or not.
* **RENAMES** `cmark_gfm_extensions_tasklist_state_is_checked` to `cmark_gfm_extensions_get_tasklist_item_checked` to better match how other functions are named. _This is due to my mistake in a previous pull request._ I hadn't done enough research on what the name should be and chose one that seemed logical at the time. The new method name doesn't read as well, but I think it matches better with the style of the others. I put a `#define` in to keep the other name, but can take that out if you prefer.
   **NOTE:** the function name I suggest is identical in form to `get_list_tight` which also returns a boolean. I would prefer to include _is_ (i.e.`cmark_gfm_extensions_get_tasklist_item_is_checked`) to make it more readable, but was going for consistency. I can change and re-submit the pull request if you agree that `cmark_gfm_extensions_get_tasklist_item_is_checked` reads slightly better.

I'm not a python programmer, so I wasn't sure how to add the appropriate tests to show that these are working, as they require getting access to the node objects and manipulating them - not just rendering to XML or CommonMark. If you give me a template to work from, then I can do that. I _have_ tested the tasklist functions in my own code (Swift, but that shouldn't matter). I have _NOT_ tested the table extension functions.