### PR TITLE
Fix bug where tasklist extension was using union in two ways.

### DIFF
--- a/extensions/tasklist.c
+++ b/extensions/tasklist.c
@@ -23,21 +23,15 @@ int cmark_gfm_extensions_set_tasklist_item_checked(cmark_node *node, bool is_che
   if (!node || !node->extension || strcmp(cmark_node_get_type_string(node), TYPE_STRING))
     return 0;
 
-  if (is_checked) {
-    node->as.opaque = (void *)CMARK_TASKLIST_CHECKED;
-    return 1;
-  }
-  else {
-    node->as.opaque = (void *)CMARK_TASKLIST_NOCHECKED;
-    return 1;
-  }
+  node->as.list.checked = is_checked;
+  return 1;
 }
 
 bool cmark_gfm_extensions_get_tasklist_item_checked(cmark_node *node) {
   if (!node || !node->extension || strcmp(cmark_node_get_type_string(node), TYPE_STRING))
     return false;
 
-  if (node->as.opaque == (void *)CMARK_TASKLIST_CHECKED) {
+  if (node->as.list.checked) {
     return true;
   }
   else {
@@ -95,11 +89,7 @@ static cmark_node *open_tasklist_item(cmark_syntax_extension *self,
   cmark_parser_advance_offset(parser, (char *)input, 3, false);
 
   // Either an upper or lower case X means the task is completed.
-  if (strstr((char*)input, "[x]") || strstr((char*)input, "[X]")) {
-    parent_container->as.opaque = (void *)CMARK_TASKLIST_CHECKED;
-  } else {
-    parent_container->as.opaque = (void *)CMARK_TASKLIST_NOCHECKED;
-  }
+  parent_container->as.list.checked = (strstr((char*)input, "[x]") || strstr((char*)input, "[X]"));
 
   return NULL;
 }
@@ -110,7 +100,7 @@ static void commonmark_render(cmark_syntax_extension *extension,
   bool entering = (ev_type == CMARK_EVENT_ENTER);
   if (entering) {
     renderer->cr(renderer);
-    if (node->as.opaque == (void *)CMARK_TASKLIST_CHECKED) {
+    if (node->as.list.checked) {
       renderer->out(renderer, node, "- [x] ", false, LITERAL);
     } else {
       renderer->out(renderer, node, "- [ ] ", false, LITERAL);
@@ -131,7 +121,7 @@ static void html_render(cmark_syntax_extension *extension,
     cmark_strbuf_puts(renderer->html, "<li");
     cmark_html_render_sourcepos(node, renderer->html, options);
     cmark_strbuf_putc(renderer->html, '>');
-    if (node->as.opaque == (void *)CMARK_TASKLIST_CHECKED) {
+    if (node->as.list.checked) {
       cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" checked=\"\" disabled=\"\" /> ");
     } else {
       cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" disabled=\"\" /> ");
@@ -143,7 +133,7 @@ static void html_render(cmark_syntax_extension *extension,
 
 static const char *xml_attr(cmark_syntax_extension *extension,
                             cmark_node *node) {
-  if (node->as.opaque == (void *)CMARK_TASKLIST_CHECKED) {
+  if (node->as.list.checked) {
     return " completed=\"true\"";
   } else {
     return " completed=\"false\"";

--- a/src/node.h
+++ b/src/node.h
@@ -21,6 +21,7 @@ typedef struct {
   cmark_delim_type delimiter;
   unsigned char bullet_char;
   bool tight;
+  bool checked; // For task list extension
 } cmark_list;
 
 typedef struct {

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -750,11 +750,24 @@ Autolink and tables.
 </ul>
 ````````````````````````````````
 
+Show that a task list and a regular list get processed the same in
+the way that sublists are created. If something works in a list
+item, then it should work the same way with a task.  The only
+difference should be the tasklist marker. So, if we use something
+other than a space or x, it won't be recognized as a task item, and
+so will be treated as a regular item.
+
 ```````````````````````````````` example
 - [x] foo
   - [ ] bar
   - [x] baz
 - [ ] bim
+
+Show a regular (non task) list to show that it has the same structure
+- [@] foo
+  - [@] bar
+  - [@] baz
+- [@] bim
 .
 <ul>
 <li><input type="checkbox" checked="" disabled="" /> foo
@@ -764,5 +777,50 @@ Autolink and tables.
 </ul>
 </li>
 <li><input type="checkbox" disabled="" /> bim</li>
+</ul>
+<p>Show a regular (non task) list to show that it has the same structure</p>
+<ul>
+<li>[@] foo
+<ul>
+<li>[@] bar</li>
+<li>[@] baz</li>
+</ul>
+</li>
+<li>[@] bim</li>
+</ul>
+````````````````````````````````
+Use a larger indent -- a task list and a regular list should produce
+the same structure.
+
+```````````````````````````````` example
+- [x] foo
+    - [ ] bar
+    - [x] baz
+- [ ] bim
+
+Show a regular (non task) list to show that it has the same structure
+- [@] foo
+    - [@] bar
+    - [@] baz
+- [@] bim
+.
+<ul>
+<li><input type="checkbox" checked="" disabled="" /> foo
+<ul>
+<li><input type="checkbox" disabled="" /> bar</li>
+<li><input type="checkbox" checked="" disabled="" /> baz</li>
+</ul>
+</li>
+<li><input type="checkbox" disabled="" /> bim</li>
+</ul>
+<p>Show a regular (non task) list to show that it has the same structure</p>
+<ul>
+<li>[@] foo
+<ul>
+<li>[@] bar</li>
+<li>[@] baz</li>
+</ul>
+</li>
+<li>[@] bim</li>
 </ul>
 ````````````````````````````````


### PR DESCRIPTION
The tasklist extension was using the "as" union both as a list
(in `tasklist.c:parse_node_item_prefix`) and as an opaque
(in `tasklist.c:open_tasklist_item`). This meant that strange bugs
could occur because the underlying union memory was being overwritten.

It manifested when using nested task lists indented by 4 spaces (see #168)

To fix this, I added the "checked" field to the `cmark_list` structure.
This allows the tasklist extension to use the `as.list` union member
in all its operations. This is appropriate because a tasklist item
is a list item in all essentials -- and even shares the CMARK_NODE_ITEM
type.

I also updated the tests in extensions.txt to include a non-task list with the same structure to show that the structure doesn't depend on whether or not it is a taskitem. If you look at only the test, you will see that the test fails for the current implementation, and passes with these fixes.

This fixes #168.