### PR TITLE
Correct path to artifact

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ build_script:
   - 'tools\appveyor-build.bat'
 
 artifacts:
-  - path: build/src/cmark.exe
-    name: cmark.exe
+  - path: build/src/cmark-gfm.exe
+    name: cmark-gfm.exe
 
 test_script:
   - 'nmake test'


### PR DESCRIPTION
https://ci.appveyor.com/project/github/cmark does not have any artifacts because cmark executable is different.