### PR TITLE
Made cmark re-entrant by storing special chars data per parser object

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -109,6 +109,20 @@ static void cmark_parser_dispose(cmark_parser *parser) {
     cmark_map_free(parser->refmap);
 }
 
+// "\r\n\\`&_*[]<!"
+static const int8_t SPECIAL_CHARS[256] = {
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1,
+      1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
 static void cmark_parser_reset(cmark_parser *parser) {
   cmark_llist *saved_exts = parser->syntax_extensions;
   cmark_llist *saved_inline_exts = parser->inline_syntax_extensions;
@@ -132,6 +146,8 @@ static void cmark_parser_reset(cmark_parser *parser) {
   parser->syntax_extensions = saved_exts;
   parser->inline_syntax_extensions = saved_inline_exts;
   parser->options = saved_options;
+
+  memcpy(parser->SPECIAL_CHARS, SPECIAL_CHARS, sizeof(SPECIAL_CHARS));
 }
 
 cmark_parser *cmark_parser_new_with_mem(int options, cmark_mem *mem) {
@@ -416,9 +432,9 @@ void cmark_manage_extensions_special_characters(cmark_parser *parser, int add) {
     for (tmp_char = ext->special_inline_chars; tmp_char; tmp_char=tmp_char->next) {
       unsigned char c = (unsigned char)(size_t)tmp_char->data;
       if (add)
-        cmark_inlines_add_special_character(c, ext->emphasis);
+        cmark_inlines_add_special_character(parser, c, ext->emphasis);
       else
-        cmark_inlines_remove_special_character(c, ext->emphasis);
+        cmark_inlines_remove_special_character(parser, c, ext->emphasis);
     }
   }
 }

--- a/src/inlines.h
+++ b/src/inlines.h
@@ -19,8 +19,8 @@ void cmark_parse_inlines(cmark_parser *parser,
 bufsize_t cmark_parse_reference_inline(cmark_mem *mem, cmark_chunk *input,
                                        cmark_map *refmap);
 
-void cmark_inlines_add_special_character(unsigned char c, bool emphasis);
-void cmark_inlines_remove_special_character(unsigned char c, bool emphasis);
+void cmark_inlines_add_special_character(cmark_parser* parser, unsigned char, bool emphasis);
+void cmark_inlines_remove_special_character(cmark_parser* parser, unsigned char, bool emphasis);
 
 #ifdef __cplusplus
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -49,6 +49,8 @@ struct cmark_parser {
   cmark_llist *syntax_extensions;
   cmark_llist *inline_syntax_extensions;
   cmark_ispunct_func backslash_ispunct;
+  int8_t SPECIAL_CHARS[256];
+  int8_t SKIP_CHARS[256];
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Before this change, if you use cmark concurrently, you could run into concurrent access because the `SPECIAL_CHARS` table was globally shared with potential read and write.

This change stores the table per `cmark_parser` instance and solves the problem.

This bug was found at Google using [thread sanitizer](https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual)