### PR TITLE
Make normalize test compatible with python 3.8

### DIFF
--- a/test/normalize.py
+++ b/test/normalize.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from html.parser import HTMLParser
 import urllib
+import html
 
 try:
     from html.parser import HTMLParseError
@@ -66,7 +67,7 @@ class MyHTMLParser(HTMLParser):
                     self.output += ("=" + '"' +
                             urllib.quote(urllib.unquote(v), safe='/') + '"')
                 elif v != None:
-                    self.output += ("=" + '"' + cgi.escape(v,quote=True) + '"')
+                    self.output += ("=" + '"' + html.escape(v,quote=True) + '"')
         self.output += ">"
         self.last_tag = tag
         self.last = "starttag"


### PR DESCRIPTION
Python 3.8 has removed the cgi.escape function, which had been
deprecated since version 3.2. html.escape does the same thing, use
that instead.

Signed-off-by: Keith Packard <keithp@keithp.com>