### PR TITLE
add setext heading after table example

### DIFF
--- a/test/spec.txt
+++ b/test/spec.txt
@@ -3454,6 +3454,39 @@ bar
 <p>bar</p>
 ````````````````````````````````
 
+A [setext heading] does not break a table without a blank line above it:
+
+```````````````````````````````` example table
+| abc | def |
+| --- | --- |
+| bar | baz |
+bar
+===
+.
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>bar</td>
+<td>baz</td>
+</tr>
+<tr>
+<td>bar</td>
+<td></td>
+</tr>
+<tr>
+<td>===</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
 The header row must match the [delimiter row] in the number of cells.  If not,
 a table will not be recognized:
 


### PR DESCRIPTION
Add an example showing that a setext heading does not break a table without a blank line above it

fixes #179