### PR TITLE
Add Swift Package Manager Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "swift-cmark-gfm",
+
+    products: [
+        .library(name: "swift-cmark-gfm", targets: ["cmark-gfm"]),
+    ],
+
+    targets: [
+        // Exclude the main file so cmark is built as a library.
+        .target(name: "cmark-gfm", path: "src", exclude: ["main.c"]),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -155,6 +155,31 @@ You can cross-compile a Windows binary and dll on linux if you have the
 
 The binaries will be in `build-mingw/windows/bin`.
 
+Installing (Swift Package Manager)
+----------------------------------
+
+To include `swift-cmark-gfm` in your Swift package add the following dependency to your Package.swift:
+
+```swift
+.package(url: "https://github.com/unsignedapps/swift-cmark-gfm.git", from: "0.16.5.1")
+```
+
+**Note:** The first version that has Swift Package Manager support is 0.16.5.1.
+
+Don't forget to include the library in your target:
+
+```swift
+.target(name: "BestExampleApp", dependencies: [ "swift-cmark-gfm" ])
+```
+
+And import the module in your code:
+
+```swift
+import Foundation
+import cmark_gfm
+```
+You can find the Swift docs by ⌘-clicking on the import statement and choosing _Jump to Definition_, or by googling the cmark man pages. The interface is the same as the C one.
+
 Usage
 -----
 

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,76 @@
+#ifndef CMARK_CONFIG_H
+#define CMARK_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HAVE_STDBOOL_H
+
+#ifdef HAVE_STDBOOL_H
+  #include <stdbool.h>
+#elif !defined(__cplusplus)
+  typedef char bool;
+#endif
+
+#define HAVE___BUILTIN_EXPECT
+
+#define HAVE___ATTRIBUTE__
+
+#ifdef HAVE___ATTRIBUTE__
+  #define CMARK_ATTRIBUTE(list) __attribute__ (list)
+#else
+  #define CMARK_ATTRIBUTE(list)
+#endif
+
+#ifndef CMARK_INLINE
+  #if defined(_MSC_VER) && !defined(__cplusplus)
+    #define CMARK_INLINE __inline
+  #else
+    #define CMARK_INLINE inline
+  #endif
+#endif
+
+/* snprintf and vsnprintf fallbacks for MSVC before 2015,
+   due to Valentin Milea http://stackoverflow.com/questions/2915672/
+*/
+
+#if defined(_MSC_VER) && _MSC_VER < 1900
+
+#include <stdio.h>
+#include <stdarg.h>
+
+#define snprintf c99_snprintf
+#define vsnprintf c99_vsnprintf
+
+CMARK_INLINE int c99_vsnprintf(char *outBuf, size_t size, const char *format, va_list ap)
+{
+    int count = -1;
+
+    if (size != 0)
+        count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
+    if (count == -1)
+        count = _vscprintf(format, ap);
+
+    return count;
+}
+
+CMARK_INLINE int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
+{
+    int count;
+    va_list ap;
+
+    va_start(ap, format);
+    count = c99_vsnprintf(outBuf, size, format, ap);
+    va_end(ap);
+
+    return count;
+}
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/include/cmark-gfm.h
+++ b/src/include/cmark-gfm.h
@@ -1,0 +1,2 @@
+#include "../cmark-gfm.h"
+#include "../node.h"

--- a/src/include/cmark-gfm_export.h
+++ b/src/include/cmark-gfm_export.h
@@ -1,0 +1,42 @@
+
+#ifndef CMARK_GFM_EXPORT_H
+#define CMARK_GFM_EXPORT_H
+
+#ifdef CMARK_GFM_STATIC_DEFINE
+#  define CMARK_GFM_EXPORT
+#  define CMARK_GFM_NO_EXPORT
+#else
+#  ifndef CMARK_GFM_EXPORT
+#    ifdef libcmark_gfm_EXPORTS
+        /* We are building this library */
+#      define CMARK_GFM_EXPORT __attribute__((visibility("default")))
+#    else
+        /* We are using this library */
+#      define CMARK_GFM_EXPORT __attribute__((visibility("default")))
+#    endif
+#  endif
+
+#  ifndef CMARK_GFM_NO_EXPORT
+#    define CMARK_GFM_NO_EXPORT __attribute__((visibility("hidden")))
+#  endif
+#endif
+
+#ifndef CMARK_GFM_DEPRECATED
+#  define CMARK_GFM_DEPRECATED __attribute__ ((__deprecated__))
+#endif
+
+#ifndef CMARK_GFM_DEPRECATED_EXPORT
+#  define CMARK_GFM_DEPRECATED_EXPORT CMARK_GFM_EXPORT CMARK_GFM_DEPRECATED
+#endif
+
+#ifndef CMARK_GFM_DEPRECATED_NO_EXPORT
+#  define CMARK_GFM_DEPRECATED_NO_EXPORT CMARK_GFM_NO_EXPORT CMARK_GFM_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef CMARK_GFM_NO_DEPRECATED
+#    define CMARK_GFM_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* CMARK_GFM_EXPORT_H */

--- a/src/include/cmark-gfm_version.h
+++ b/src/include/cmark-gfm_version.h
@@ -1,0 +1,7 @@
+#ifndef CMARK_GFM_VERSION_H
+#define CMARK_GFM_VERSION_H
+
+#define CMARK_GFM_VERSION ((0 << 24) | (29 << 16) | (0 << 8) | 0)
+#define CMARK_GFM_VERSION_STRING "0.29.0.gfm.0"
+
+#endif


### PR DESCRIPTION
This PR adds support for Swift Package Manager by pulling in the `Package.swift` used by [swift-cmark](https://github.com/apple/swift-cmark.git) and by generating the built headers necessary so SwiftPM can work its magic.

Note: The _library_ is `swift-cmark-gfm` to differentiate itself from GitHub's [cmark-gfm](https://github.com/github/cmark-gfm) and Apple's [swift-cmark](https://github.com/apple/swift-cmark), but the _module_ is still `cmark-gfm`.