### PR TITLE
[Autolink] Store positioning info for url_match

### DIFF
--- a/extensions/autolink.c
+++ b/extensions/autolink.c
@@ -245,6 +245,11 @@ static cmark_node *url_match(cmark_parser *parser, cmark_node *parent,
   cmark_node *text = cmark_node_new_with_mem(CMARK_NODE_TEXT, parser->mem);
   text->as.literal = url;
   cmark_node_append_child(node, text);
+  
+  node->start_line = text->start_line = node->end_line = text->end_line = cmark_inline_parser_get_line(inline_parser);
+
+  node->start_column = text->start_column = max_rewind - rewind;
+  node->end_column = text->end_column = cmark_inline_parser_get_column(inline_parser) - 1;
 
   return node;
 }


### PR DESCRIPTION
Currently for the autolink extension, only `www_match` correctly returns correct positioning when calling `cmark_node_get_start_line`/`cmark_node_get_start_column`/`cmark_node_get_end_line`/`cmark_node_get_end_column`. This is done here: https://github.com/github/cmark-gfm/blob/master/extensions/autolink.c#L191-L193

This PR adds positioning support for the `url_match` function.