### PR TITLE
Various fixes for source-position information

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -1062,19 +1062,26 @@ static void source_pos_inlines(test_batch_runner *runner) {
   {
     static const char markdown[] =
       "*first*\n"
-      "second\n";
+      "second\n"
+      "\n"
+      "   <http://example.com>";
 
     cmark_node *doc = cmark_parse_document(markdown, sizeof(markdown) - 1, CMARK_OPT_DEFAULT);
     char *xml = cmark_render_xml(doc, CMARK_OPT_DEFAULT | CMARK_OPT_SOURCEPOS);
     STR_EQ(runner, xml, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                         "<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n"
-                        "<document sourcepos=\"1:1-2:6\" xmlns=\"http://commonmark.org/xml/1.0\">\n"
+                        "<document sourcepos=\"1:1-4:23\" xmlns=\"http://commonmark.org/xml/1.0\">\n"
                         "  <paragraph sourcepos=\"1:1-2:6\">\n"
                         "    <emph sourcepos=\"1:1-1:7\">\n"
                         "      <text sourcepos=\"1:2-1:6\" xml:space=\"preserve\">first</text>\n"
                         "    </emph>\n"
                         "    <softbreak />\n"
                         "    <text sourcepos=\"2:1-2:6\" xml:space=\"preserve\">second</text>\n"
+                        "  </paragraph>\n"
+                        "  <paragraph sourcepos=\"4:4-4:23\">\n"
+                        "    <link sourcepos=\"4:4-4:23\" destination=\"http://example.com\" title=\"\">\n"
+                        "      <text sourcepos=\"4:5-4:22\" xml:space=\"preserve\">http://example.com</text>\n"
+                        "    </link>\n"
                         "  </paragraph>\n"
                         "</document>\n",
                         "sourcepos are as expected");

--- a/api_test/main.c
+++ b/api_test/main.c
@@ -1005,13 +1005,18 @@ static void source_pos(test_batch_runner *runner) {
     ">\n"
     "> 2. Yes, okay.\n"
     ">    ![ok](hi \"yes\")\n"
-    "<!-- HTML Comment -->";
+    "<!-- HTML Comment -->\n"
+    "\n"
+    "what happens if we spread a link [across multiple\n"
+    "lines][anchor]\n"
+    "\n"
+    "[anchor]: http://example.com\n";
 
   cmark_node *doc = cmark_parse_document(markdown, sizeof(markdown) - 1, CMARK_OPT_DEFAULT);
   char *xml = cmark_render_xml(doc, CMARK_OPT_DEFAULT | CMARK_OPT_SOURCEPOS);
   STR_EQ(runner, xml, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                       "<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n"
-                      "<document sourcepos=\"1:1-11:21\" xmlns=\"http://commonmark.org/xml/1.0\">\n"
+                      "<document sourcepos=\"1:1-16:28\" xmlns=\"http://commonmark.org/xml/1.0\">\n"
                       "  <heading sourcepos=\"1:1-1:13\" level=\"1\">\n"
                       "    <text sourcepos=\"1:3-1:5\" xml:space=\"preserve\">Hi </text>\n"
                       "    <emph sourcepos=\"1:6-1:12\">\n"
@@ -1055,6 +1060,14 @@ static void source_pos(test_batch_runner *runner) {
                       "  </block_quote>\n"
                       "  <html_block sourcepos=\"11:1-11:21\" xml:space=\"preserve\">&lt;!-- HTML Comment --&gt;\n"
                       "</html_block>\n"
+                      "  <paragraph sourcepos=\"13:1-14:14\">\n"
+                      "    <text sourcepos=\"13:1-13:33\" xml:space=\"preserve\">what happens if we spread a link </text>\n"
+                      "    <link sourcepos=\"13:34-14:14\" destination=\"http://example.com\" title=\"\">\n"
+                      "      <text sourcepos=\"13:35-13:49\" xml:space=\"preserve\">across multiple</text>\n"
+                      "      <softbreak />\n"
+                      "      <text sourcepos=\"14:1-14:5\" xml:space=\"preserve\">lines</text>\n"
+                      "    </link>\n"
+                      "  </paragraph>\n"
                       "</document>\n",
          "sourcepos are as expected");
   free(xml);

--- a/api_test/main.c
+++ b/api_test/main.c
@@ -1004,13 +1004,14 @@ static void source_pos(test_batch_runner *runner) {
     ">    Sure.\n"
     ">\n"
     "> 2. Yes, okay.\n"
-    ">    ![ok](hi \"yes\")\n";
+    ">    ![ok](hi \"yes\")\n"
+    "<!-- HTML Comment -->";
 
   cmark_node *doc = cmark_parse_document(markdown, sizeof(markdown) - 1, CMARK_OPT_DEFAULT);
   char *xml = cmark_render_xml(doc, CMARK_OPT_DEFAULT | CMARK_OPT_SOURCEPOS);
   STR_EQ(runner, xml, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                       "<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n"
-                      "<document sourcepos=\"1:1-10:20\" xmlns=\"http://commonmark.org/xml/1.0\">\n"
+                      "<document sourcepos=\"1:1-11:21\" xmlns=\"http://commonmark.org/xml/1.0\">\n"
                       "  <heading sourcepos=\"1:1-1:13\" level=\"1\">\n"
                       "    <text sourcepos=\"1:3-1:5\" xml:space=\"preserve\">Hi </text>\n"
                       "    <emph sourcepos=\"1:6-1:12\">\n"
@@ -1052,6 +1053,8 @@ static void source_pos(test_batch_runner *runner) {
                       "      </item>\n"
                       "    </list>\n"
                       "  </block_quote>\n"
+                      "  <html_block sourcepos=\"11:1-11:21\" xml:space=\"preserve\">&lt;!-- HTML Comment --&gt;\n"
+                      "</html_block>\n"
                       "</document>\n",
          "sourcepos are as expected");
   free(xml);

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -289,7 +289,8 @@ static cmark_node *finalize(cmark_parser *parser, cmark_node *b) {
     b->end_column = parser->last_line_length;
   } else if (S_type(b) == CMARK_NODE_DOCUMENT ||
              (S_type(b) == CMARK_NODE_CODE_BLOCK && b->as.code.fenced) ||
-             (S_type(b) == CMARK_NODE_HEADING && b->as.heading.setext)) {
+             (S_type(b) == CMARK_NODE_HEADING && b->as.heading.setext) ||
+             (parser->line_number - 1 < b->end_line)) {
     b->end_line = parser->line_number;
     b->end_column = parser->curline.size;
     if (b->end_column && parser->curline.ptr[b->end_column - 1] == '\n')

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -150,8 +150,8 @@ static CMARK_INLINE cmark_node *make_autolink(subject *subj,
   link->as.link.url = cmark_clean_autolink(subj->mem, &url, is_email);
   link->as.link.title = cmark_chunk_literal("");
   link->start_line = link->end_line = subj->line;
-  link->start_column = start_column + 1;
-  link->end_column = end_column + 1;
+  link->start_column = start_column + 1 + subj->column_offset + subj->block_offset;
+  link->end_column = end_column + 1 + subj->column_offset + subj->block_offset;
   cmark_node_append_child(link, make_str_with_entities(subj, start_column + 1, end_column - 1, &url));
   return link;
 }

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -1163,8 +1163,9 @@ match:
   inl = make_simple(subj->mem, is_image ? CMARK_NODE_IMAGE : CMARK_NODE_LINK);
   inl->as.link.url = url;
   inl->as.link.title = title;
-  inl->start_line = inl->end_line = subj->line;
+  inl->start_line = opener->inl_text->start_line;
   inl->start_column = opener->inl_text->start_column;
+  inl->end_line = subj->line;
   inl->end_column = subj->pos + subj->column_offset + subj->block_offset;
   cmark_node_insert_before(opener->inl_text, inl);
   // Add link text:


### PR DESCRIPTION
This PR groups together a handful of fixes for source-position information. They fix a handful of related bugs where a node would have an invalid sourcepos range where the ending position turned out to be before the starting one. The issues being fixed include:

1. When an autolink (`<http://example.com>`) occurred in a block with an indentation offset, the source position range didn't account for the block offset, creating a range that was shifted over from the actual link range. This was fixed by properly applying the block offsets when creating source-position ranges for autolinks.
2. HTML comments occurring in their own block would fail to update the ending line in the parser, creating a negative-size range for the block. This was fixed by checking blocks to ensure that the parser's end-line matched the block's end line before finalizing the source position.
3. When a link node was given its source position, the parser assumed that it would never span multiple lines, creating a situation where the source-position range for a link that did span multiple lines would be erroneous or invalid. This was fixed by properly loading the parser's current line as the "ending line" for the link's source position.