### PR TITLE
Fix test/normalize.py so it runs on Python 3.8.

### DIFF
--- a/test/normalize.py
+++ b/test/normalize.py
@@ -15,6 +15,15 @@ import sys
 import re
 import cgi
 
+try:
+    # cgi.escape was removed in Python 3.8.
+    html_escape = cgi.escape
+except AttributeError:
+    import html
+
+    html_escape = html.escape
+
+
 # Normalization code, adapted from
 # https://github.com/karlcow/markdown-testsuite/
 significant_attrs = ["alt", "href", "src", "title"]
@@ -66,7 +75,7 @@ class MyHTMLParser(HTMLParser):
                     self.output += ("=" + '"' +
                             urllib.quote(urllib.unquote(v), safe='/') + '"')
                 elif v != None:
-                    self.output += ("=" + '"' + cgi.escape(v,quote=True) + '"')
+                    self.output += ("=" + '"' + html_escape(v,quote=True) + '"')
         self.output += ">"
         self.last_tag = tag
         self.last = "starttag"


### PR DESCRIPTION
`cgi.escape` was removed in Python 3.8, so fall back to
`html.escape` in that case.

Test Plan:
```
$ python3 -V
Python 3.8.6
$ make test
Running tests...
Test project /Users/mbolin/src/cmark-gfm/build
      Start  1: api_test
 1/13 Test  #1: api_test ...............................   Passed    0.18 sec
      Start  2: html_normalization
 2/13 Test  #2: html_normalization .....................   Passed    0.13 sec
      Start  3: spectest_library
 3/13 Test  #3: spectest_library .......................   Passed    0.15 sec
      Start  4: pathological_tests_library
 4/13 Test  #4: pathological_tests_library .............   Passed   58.57 sec
      Start  5: roundtriptest_library
 5/13 Test  #5: roundtriptest_library ..................   Passed    0.42 sec
      Start  6: entity_library
 6/13 Test  #6: entity_library .........................   Passed    0.12 sec
      Start  7: spectest_executable
 7/13 Test  #7: spectest_executable ....................   Passed    3.24 sec
      Start  8: smartpuncttest_executable
 8/13 Test  #8: smartpuncttest_executable ..............   Passed    0.14 sec
      Start  9: extensions_executable
 9/13 Test  #9: extensions_executable ..................   Passed    0.19 sec
      Start 10: roundtrip_extensions_executable
10/13 Test #10: roundtrip_extensions_executable ........   Passed    0.31 sec
      Start 11: option_table_prefer_style_attributes
11/13 Test #11: option_table_prefer_style_attributes ...   Passed    0.10 sec
      Start 12: option_full_info_string
12/13 Test #12: option_full_info_string ................   Passed    0.12 sec
      Start 13: regressiontest_executable
13/13 Test #13: regressiontest_executable ..............   Passed    0.15 sec

100% tests passed, 0 tests failed out of 13

Total Test time (real) =  63.83 sec
```