### PR TITLE
Adds nested footnotes; a footnote can now reference a footnote.

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -468,7 +468,6 @@ static void process_footnotes(cmark_parser *parser) {
   while ((ev_type = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
     cur = cmark_iter_get_node(iter);
     if (ev_type == CMARK_EVENT_EXIT && cur->type == CMARK_NODE_FOOTNOTE_DEFINITION) {
-      cmark_node_unlink(cur);
       cmark_footnote_create(map, cur);
     }
   }
@@ -515,8 +514,10 @@ static void process_footnotes(cmark_parser *parser) {
     qsort(map->sorted, map->size, sizeof(cmark_map_entry *), sort_footnote_by_ix);
     for (unsigned int i = 0; i < map->size; ++i) {
       cmark_footnote *footnote = (cmark_footnote *)map->sorted[i];
-      if (!footnote->ix)
+      if (!footnote->ix) {
+        cmark_node_unlink(footnote->node);
         continue;
+      }
       cmark_node_append_child(parser->root, footnote->node);
       footnote->node = NULL;
     }

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -645,16 +645,15 @@ Even with {"x":"y"} or 1 > 2 or whatever. Even **markdown**.
 ## Footnotes
 
 ```````````````````````````````` example
-This is some text![^1]. Other text.[^footnote].
+This is some text![^1]. Other text.[^citation].
 
-Here's a thing[^other-note].
+This line tests that "w" doesn't break the citation reference (currently broken).[^widely-cited]. Footnotes can be referenced repeatedly; even if there's not a space between the `][`s, the footnotes won't be confused for a link reference (currently broken).[^citation][^1] [^widely-cited]
 
-And another thing[^codeblock-note].
+Here's another thing[^codeblock-note]. Footnote references can use lots of different characters (currently broken).[^sphinx-of-black-quartz_judge-my-vow-0123456789] [^widely-cited]
 
 This doesn't have a referent[^nope].
 
-
-[^other-note]:       no code block here (spaces are stripped away)
+[^widely-cited]:       no code block here (spaces are stripped away). This footnote is cited three times, and so we should see three backrefs.
 
 [^codeblock-note]:
         this is now a code block (8 spaces indentation)
@@ -663,26 +662,28 @@ This doesn't have a referent[^nope].
 
 [^nested]: Footnotes can be nested.
 
-Hi!
+Hi! Footnote _definitions_ should be removed from the text, and reinserted at the bottom.
 
-[^footnote]:
+[^citation]:
     > Blockquotes can be in a footnote.
 
         as well as code blocks
 
     or, naturally, simple paragraphs.
 
-[^unused]: This is unused.
+[^sphinx-of-black-quartz_judge-my-vow-0123456789]: This works.
+
+[^unused]: This is unused, and will be removed.
 .
 <p>This is some text!<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup>. Other text.<sup class="footnote-ref"><a href="#fn2" id="fnref2">2</a></sup>.</p>
-<p>Here's a thing<sup class="footnote-ref"><a href="#fn3" id="fnref3">3</a></sup>.</p>
-<p>And another thing<sup class="footnote-ref"><a href="#fn4" id="fnref4">4</a></sup>.</p>
+<p>This line tests that &quot;w&quot; doesn't break the citation reference (currently broken).[^widely-cited]. Footnotes can be referenced repeatedly; even if there's not a space between the <code>][</code>s, the footnotes won't be confused for a link reference (currently broken).<sup class="footnote-ref"><a href="#fn2" id="fnref2">2</a></sup> [^widely-cited]</p>
+<p>Here's another thing<sup class="footnote-ref"><a href="#fn3" id="fnref3">3</a></sup>. Footnote references can use lots of different characters (currently broken).[^sphinx-of-black-quartz_judge-my-vow-0123456789] [^widely-cited]</p>
 <p>This doesn't have a referent[^nope].</p>
-<p>Hi!</p>
+<p>Hi! Footnote <em>definitions</em> should be removed from the text, and reinserted at the bottom.</p>
 <section class="footnotes">
 <ol>
 <li id="fn1">
-<p>Some <em>bolded</em> footnote definition.<sup class="footnote-ref"><a href="#fn5" id="fnref5">5</a></sup> <a href="#fnref1" class="footnote-backref">↩</a></p>
+<p>Some <em>bolded</em> footnote definition.<sup class="footnote-ref"><a href="#fn4" id="fnref4">4</a></sup> <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
 <li id="fn2">
 <blockquote>
@@ -693,15 +694,12 @@ Hi!
 <p>or, naturally, simple paragraphs. <a href="#fnref2" class="footnote-backref">↩</a></p>
 </li>
 <li id="fn3">
-<p>no code block here (spaces are stripped away) <a href="#fnref3" class="footnote-backref">↩</a></p>
-</li>
-<li id="fn4">
 <pre><code>this is now a code block (8 spaces indentation)
 </code></pre>
-<a href="#fnref4" class="footnote-backref">↩</a>
+<a href="#fnref3" class="footnote-backref">↩</a>
 </li>
-<li id="fn5">
-<p>Footnotes can be nested. <a href="#fnref5" class="footnote-backref">↩</a></p>
+<li id="fn4">
+<p>Footnotes can be nested. <a href="#fnref4" class="footnote-backref">↩</a></p>
 </li>
 </ol>
 </section>

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -659,7 +659,9 @@ This doesn't have a referent[^nope].
 [^codeblock-note]:
         this is now a code block (8 spaces indentation)
 
-[^1]: Some *bolded* footnote definition.
+[^1]: Some *bolded* footnote definition.[^nested]
+
+[^nested]: Footnotes can be nested.
 
 Hi!
 
@@ -680,7 +682,7 @@ Hi!
 <section class="footnotes">
 <ol>
 <li id="fn1">
-<p>Some <em>bolded</em> footnote definition. <a href="#fnref1" class="footnote-backref">↩</a></p>
+<p>Some <em>bolded</em> footnote definition.<sup class="footnote-ref"><a href="#fn5" id="fnref5">5</a></sup> <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
 <li id="fn2">
 <blockquote>
@@ -697,6 +699,9 @@ Hi!
 <pre><code>this is now a code block (8 spaces indentation)
 </code></pre>
 <a href="#fnref4" class="footnote-backref">↩</a>
+</li>
+<li id="fn5">
+<p>Footnotes can be nested. <a href="#fnref5" class="footnote-backref">↩</a></p>
 </li>
 </ol>
 </section>


### PR DESCRIPTION
Hello!

### What?
This PR adds support for "nested" footnotes to `cmark-gfm`. A nested footnote happens when a footnote references another footnote, like so:

```markdown
A paragraph[^footnote].

[^footnote]: A long, interesting side note.[^citation]

[^citation]: I am a nested footnote.
```

### How?
The change itself is very simple, just three lines plus a test. It works like this this: the `process_footnotes` function iterates thru the document's nodes in two phases: once to fetch footnote definitions, and a second time to fetch footnote references.

_Before_, once we found a footnote definition we would `unlink` the definition from the document, so it could be reinserted at the bottom of the tree. If a footnote definition is never used, it never gets re-inserted at the bottom. This prevented any footnote references _inside a footnote definition_ from being picked up.

_Now_, we wait to `unlink` footnotes until after the footnote reference phase. Once all references are found, we iterate over every footnote. If a footnote was used, then we call `append_child_node` on its definition to move it to the bottom of the tree.

Because of how `append_child_node` works, this edits the node/tree in place, the node is moved to the bottom and calling `unlink` is unnecessary. If a footnote is not used, then we `unlink` it thereby deleting it from the document.

### Why?

I am in the process of standardizing the markdown renderer I use for my writing away from `redcarpet` and onto `cmark-gfm`/`commonmarker`.

I thus discovered that `cmark-gfm` does not support nested footnotes. I find nested footnotes useful for adding citations to footnotes.