### PR TITLE
Correctly process footnotes when autolink is enabled

### DIFF
--- a/src/inlines.c
+++ b/src/inlines.c
@@ -1140,42 +1140,47 @@ noMatch:
       opener->inl_text->next->type == CMARK_NODE_TEXT) {
 
     cmark_chunk *literal = &opener->inl_text->next->as.literal;
+    // look back to the opening '[', and skip ahead to the next character
     // if we're looking at a '[^' sequence, let's call it a footnote reference.
     if (literal->len > 1 && literal->data[0] == '^') {
       cmark_node *fnref = make_simple(subj->mem, CMARK_NODE_FOOTNOTE_REFERENCE);
 
       // the start and end of the footnote ref is the opening and closing brace
-      // i.e. the subject's current position plus the opener's start_col
+      // i.e. the subject's current position, and the opener's start_column
       int fnref_end_column = subj->pos + subj->column_offset + subj->block_offset;
       int fnref_start_column = opener->inl_text->start_column;
 
-      // although any given node delineates a specific bit of text, its literal
-      // is a pointer to the rest of the line.
+      // any given node delineates a substring of the line being processed,
+      // with the remainder of the line being pointed to thru its 'literal'
+      // struct member.
       // here, we copy the literal's pointer, moving it past the '^' character
       // for a length equal to the size of footnote reference text.
       // i.e. end_col minus start_col, minus the [ and the ^ characters
       //
-      // this copies the whole footnote reference string, even if between the
-      // `opener` and the subject's current position there are any other nodes
+      // this copies the footnote reference string, even if between the
+      // `opener` and the subject's current position there are other nodes
       fnref->as.literal = cmark_chunk_dup(literal, 1, (fnref_end_column - fnref_start_column) - 2);
       fnref->start_line = fnref->end_line = subj->line;
       fnref->start_column = fnref_start_column;
       fnref->end_column = fnref_end_column;
 
       // we then replace the opener with this new fnref node, the net effect
-      // being replacing the opening '[' text node with a `^footnote-ref` node.
+      // being replacing the opening '[' text node with a `^footnote-ref]` node.
       cmark_node_insert_before(opener->inl_text, fnref);
 
-      // sometimes, there may be several nodes between the opener '[', the '^'
-      // and the node holding the closing ']'. this happens for ex due to the
-      // autolink feature looking for links and splitting up text nodes when
-      // it encounters a 'w' in hopes of matching a 'www.' substring.
+      // sometimes, the footnote reference text gets parsed into multiple nodes
+      // i.e. '[^example]' parsed into '[', '^exam', 'ple]'.
+      // this happens for ex with the autolink extension. when the autolinker
+      // finds the 'w' character, it will split the text into multiple nodes
+      // in hopes of being able to match a 'www.' substring.
       //
       // because this function is called one character at a time via the
       // `parse_inlines` function, and the current subj->pos is pointing at the
       // closing ] brace, and because we copy all the text between the [ ]
-      // braces, any existing nodes after the opener should be superfluous,
-      // and we can walk thru the list and free them all up.
+      // braces, we should be able to safely ignore and delete any nodes after
+      // the opener->inl_text->next.
+      //
+      // therefore, here we walk thru the list and free them all up
       cmark_node *next_node;
       cmark_node *current_node = opener->inl_text->next;
       while(current_node) {

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -57,9 +57,6 @@ typedef struct subject{
   bool scanned_for_backticks;
 } subject;
 
-
-void print_type(int cmark_type);
-void dump_node(cmark_node *node);
 // Extensions may populate this.
 static int8_t SKIP_CHARS[256];
 
@@ -75,19 +72,6 @@ static int parse_inline(cmark_parser *parser, subject *subj, cmark_node *parent,
 static void subject_from_buf(cmark_mem *mem, int line_number, int block_offset, subject *e,
                              cmark_chunk *buffer, cmark_map *refmap);
 static bufsize_t subject_find_special_char(subject *subj, int options);
-
-void print_ast(cmark_parser *parser) {
-  cmark_iter *iter = cmark_iter_new(parser->root);
-  cmark_node *cur;
-  cmark_event_type ev_type;
-
-  while ((ev_type = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
-    cur = cmark_iter_get_node(iter);
-    printf("FULL PRINT [%.*s]\n", cur->as.literal.len, cur->as.literal.data);
-    print_type(cur->type);
-  }
-
-}
 
 // Create an inline with a literal string value.
 static CMARK_INLINE cmark_node *make_literal(subject *subj, cmark_node_type t,
@@ -1061,7 +1045,6 @@ static cmark_node *handle_close_bracket(cmark_parser *parser, subject *subj) {
   int found_label;
   cmark_node *tmp, *tmpnext;
   bool is_image;
-  cmark_node *node;
 
   advance(subj); // advance past ]
   initial_pos = subj->pos;
@@ -1150,140 +1133,62 @@ static cmark_node *handle_close_bracket(cmark_parser *parser, subject *subj) {
   }
 
 noMatch:
-printf("#######\n");
-  print_ast(parser);
-    /* printf("full subject: %s\n", subj->input.data); */
-    printf("full ref: %.*s\n",subj->pos - opener->inl_text->start_column,  subj->input.data + opener->inl_text->start_column);
-  node = opener->inl_text;
-  /* printf("no match, what's in the opener?: %s\n", opener->inl_text->as.literal.data); */
-  dump_node(node);
-  /* printf("end_col? %d\n\n", subj->pos + subj->column_offset + subj->block_offset); */
-  int counter = 0;
-  while((node = node->next)) {
-    printf("count %d\n", ++counter);
-    printf("full literal: %s\n", node->as.literal.data);
-    dump_node(node);
-    printf("token \%.*s\n", (node->end_column - node->start_column) + 1, node->as.literal.data);
-    printf("subject \%.*s\n", ((subj->pos + subj->column_offset + subj->block_offset) - node->start_column) + 1, node->as.literal.data);
-  }
-
-
-  
-  /* printf("nomatch for: %s\n", opener->inl_text->next->as.literal.data); */
-  /* printf("token \%.*s\n", (opener->inl_text->next->end_column - opener->inl_text->next->start_column) + 1, opener->inl_text->next->as.literal.data); */
-  /* dump_node(opener->inl_text->next); */
-  /* print_type(opener->inl_text->next->type); */
-  /* if (opener->inl_text->next->next) { */
-  /*   printf("next-next for: %s\n", opener->inl_text->next->next->as.literal.data); */
-  /*   #<{(| print_type(opener->inl_text->next->next->type); |)}># */
-  /*   dump_node(opener->inl_text->next->next); */
-  /*  */
-  /*   if (!opener->inl_text->next->next->next) { */
-  /*     printf("no 3 next!\n"); */
-  /*   } else { */
-  /*     printf("next-next-next for: %s\n", opener->inl_text->next->next->next->as.literal.data); */
-  /*   dump_node(opener->inl_text->next->next->next); */
-  /*   } */
-  /* } */
-
-/**
-  if (parser->options & CMARK_OPT_FOOTNOTES &&
-      opener->inl_text->next &&
-      opener->inl_text->next->type == CMARK_NODE_TEXT) {
-
-    cmark_chunk *literal = &opener->inl_text->next->as.literal;
-    if (literal->len > 1 && literal->data[0] == '^') {
-      inl = make_simple(subj->mem, CMARK_NODE_FOOTNOTE_REFERENCE);
-      inl->as.literal = cmark_chunk_dup(literal, 1, literal->len - 1);
-      inl->start_line = inl->end_line = subj->line;
-      inl->start_column = opener->inl_text->start_column;
-      inl->end_column = subj->pos + subj->column_offset + subj->block_offset;
-
-      cmark_node_insert_before(opener->inl_text, inl);
-
-      cmark_node *node_to_del;
-      cmark_node *cursor;
-      cursor = opener->inl_text->next;
-      while(cursor) {
-        node_to_del = cursor;
-        cursor = cursor->next;
-        cmark_node_free(node_to_del);
-      }
-      cmark_node_free(opener->inl_text);
-
-      process_emphasis(parser, subj, opener->previous_delimiter);
-      pop_bracket(subj);
-      return NULL;
-    }
-  }**/
-  
-
-  if (parser->options & CMARK_OPT_FOOTNOTES &&
-      opener->inl_text->next &&
-      opener->inl_text->next->type == CMARK_NODE_TEXT) {
-
-    cmark_chunk *literal = &opener->inl_text->next->as.literal;
-    if (literal->len > 1 && literal->data[0] == '^') {
-      printf("whoa nelly! \n");
-      inl = make_simple(subj->mem, CMARK_NODE_FOOTNOTE_REFERENCE);
-
-      int literal_end_column = subj->pos + subj->column_offset + subj->block_offset;
-      int literal_start_column =  opener->inl_text->start_column;
-
-      inl->as.literal = cmark_chunk_dup(literal, 1, (literal_end_column - literal_start_column) - 2);
-      inl->start_line = inl->end_line = subj->line;
-      inl->start_column = opener->inl_text->start_column;
-      inl->end_column = subj->pos + subj->column_offset + subj->block_offset;
-      cmark_node_insert_before(opener->inl_text, inl);
-      dump_node(inl);
-      printf("inl insert \%.*s\n", (inl->end_column - inl->start_column), inl->as.literal.data);
-
-      // walk thru list and free them all up
-      cmark_node *cursor = opener->inl_text->next;
-      cmark_node *temp;
-      while(cursor) {
-        printf("cursor \%.*s\n", (cursor->end_column - cursor->start_column) + 1, cursor->as.literal.data);
-        temp = cursor->next;
-        cmark_node_free(cursor);
-        cursor = temp;
-      }
-
-      /* cmark_node_free(opener->inl_text->next); */
-      cmark_node_free(opener->inl_text);
-      process_emphasis(parser, subj, opener->previous_delimiter);
-      pop_bracket(subj);
-
-      // lol
-       print_ast(parser);
-      return NULL;
-    }
-  }
-
-
-  if(false) {
   // If we fall through to here, it means we didn't match a link.
   // What if we're a footnote link?
   if (parser->options & CMARK_OPT_FOOTNOTES &&
       opener->inl_text->next &&
-      opener->inl_text->next->type == CMARK_NODE_TEXT &&
-      !opener->inl_text->next->next) {
-  printf("i saw: %s\n", opener->inl_text->next->as.literal.data);
+      opener->inl_text->next->type == CMARK_NODE_TEXT) {
+
     cmark_chunk *literal = &opener->inl_text->next->as.literal;
+    // if we're looking at a '[^' sequence, let's call it a footnote reference.
     if (literal->len > 1 && literal->data[0] == '^') {
-      printf("boom! reference\n");
-      inl = make_simple(subj->mem, CMARK_NODE_FOOTNOTE_REFERENCE);
-      inl->as.literal = cmark_chunk_dup(literal, 1, literal->len - 1);
-      inl->start_line = inl->end_line = subj->line;
-      inl->start_column = opener->inl_text->start_column;
-      inl->end_column = subj->pos + subj->column_offset + subj->block_offset;
-      cmark_node_insert_before(opener->inl_text, inl);
-      cmark_node_free(opener->inl_text->next);
+      cmark_node *fnref = make_simple(subj->mem, CMARK_NODE_FOOTNOTE_REFERENCE);
+
+      // the start and end of the footnote ref is the opening and closing brace
+      // i.e. the subject's current position plus the opener's start_col
+      int fnref_end_column = subj->pos + subj->column_offset + subj->block_offset;
+      int fnref_start_column = opener->inl_text->start_column;
+
+      // although any given node delineates a specific bit of text, its literal
+      // is a pointer to the rest of the line.
+      // here, we copy the literal's pointer, moving it past the '^' character
+      // for a length equal to the size of footnote reference text.
+      // i.e. end_col minus start_col, minus the [ and the ^ characters
+      //
+      // this copies the whole footnote reference string, even if between the
+      // `opener` and the subject's current position there are any other nodes
+      fnref->as.literal = cmark_chunk_dup(literal, 1, (fnref_end_column - fnref_start_column) - 2);
+      fnref->start_line = fnref->end_line = subj->line;
+      fnref->start_column = fnref_start_column;
+      fnref->end_column = fnref_end_column;
+
+      // we then replace the opener with this new fnref node, the net effect
+      // being replacing the opening '[' text node with a `^footnote-ref` node.
+      cmark_node_insert_before(opener->inl_text, fnref);
+
+      // sometimes, there may be several nodes between the opener '[', the '^'
+      // and the node holding the closing ']'. this happens for ex due to the
+      // autolink feature looking for links and splitting up text nodes when
+      // it encounters a 'w' in hopes of matching a 'www.' substring.
+      //
+      // because this function is called one character at a time via the
+      // `parse_inlines` function, and the current subj->pos is pointing at the
+      // closing ] brace, and because we copy all the text between the [ ]
+      // braces, any existing nodes after the opener should be superfluous,
+      // and we can walk thru the list and free them all up.
+      cmark_node *next_node;
+      cmark_node *current_node = opener->inl_text->next;
+      while(current_node) {
+        next_node = current_node->next;
+        cmark_node_free(current_node);
+        current_node = next_node;
+      }
+
       cmark_node_free(opener->inl_text);
       process_emphasis(parser, subj, opener->previous_delimiter);
       pop_bracket(subj);
       return NULL;
     }
-  }
   }
 
   pop_bracket(subj); // remove this opener from delimiter list
@@ -1291,7 +1196,6 @@ printf("#######\n");
   return make_str(subj, subj->pos - 1, subj->pos - 1, cmark_chunk_literal("]"));
 
 match:
-  printf("matched!!!!\n\n");
   inl = make_simple(subj->mem, is_image ? CMARK_NODE_IMAGE : CMARK_NODE_LINK);
   inl->as.link.url = url;
   inl->as.link.title = title;
@@ -1331,85 +1235,6 @@ match:
   }
 
   return NULL;
-}
-
-void print_type(int cmark_type) {
-  printf("%d:", cmark_type);
-  switch(cmark_type) {
-    case CMARK_NODE_DOCUMENT:
-      printf("node doc\n");
-      break;
-    case CMARK_NODE_BLOCK_QUOTE:
-      printf("node bquote\n");
-      break;
-    case CMARK_NODE_LIST:
-      printf("node list\n");
-      break;
-    case CMARK_NODE_ITEM:
-      printf("node item\n");
-      break;
-    case CMARK_NODE_CODE_BLOCK:
-      printf("node code block\n");
-      break;
-    case CMARK_NODE_HTML_BLOCK:
-      printf("node html block\n");
-      break;
-    case CMARK_NODE_CUSTOM_BLOCK:
-      printf("node custom block\n");
-      break;
-    case CMARK_NODE_PARAGRAPH:
-      printf("node para\n");
-      break;
-    case CMARK_NODE_HEADING:
-      printf("node heading\n");
-      break;
-    case CMARK_NODE_THEMATIC_BREAK:
-      printf("node break\n");
-      break;
-    case CMARK_NODE_FOOTNOTE_DEFINITION:
-      printf("node foot def\n");
-      break;
-    case CMARK_NODE_TEXT:
-      printf("node text\n");
-      break;
-    case CMARK_NODE_SOFTBREAK:
-      printf("node soft\n");
-      break;
-    case CMARK_NODE_LINEBREAK:
-      printf("node line\n");
-      break;
-    case CMARK_NODE_CODE:
-      printf("node code\n");
-      break;
-    case CMARK_NODE_HTML_INLINE:
-      printf("node html\n");
-      break;
-    case CMARK_NODE_CUSTOM_INLINE:
-      printf("node custom\n");
-      break;
-    case CMARK_NODE_EMPH:
-      printf("node emph\n");
-      break;
-    case CMARK_NODE_STRONG:
-      printf("node strong\n");
-      break;
-    case CMARK_NODE_LINK:
-      printf("node link\n");
-      break;
-    case CMARK_NODE_IMAGE:
-      printf("node imag\n");
-      break;
-    case CMARK_NODE_FOOTNOTE_REFERENCE:
-      printf("node foot ref\n");
-      break;
-    default:
-      printf("wut\n");
-      break;
-  }
-}
-
-void dump_node(cmark_node *node) {
-  printf("startline %d, startcol %d, endline %d, endcol %d, offset %d, type %d\n", node->start_line, node->start_column, node->end_line, node->end_column, node->internal_offset, node->type);
 }
 
 // Parse a hard or soft linebreak, returning an inline.

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -649,7 +649,7 @@ This is some text![^1]. Other text.[^footnote].
 
 Here's a thing[^other-note].
 
-And another thing[^codeblock-note].
+And another thing[^codeblock-note]. Footnotes can use lots of different characters.[^sphinx-of-black-quartz_judge-my-vow]
 
 This doesn't have a referent[^nope].
 
@@ -670,11 +670,13 @@ Hi!
 
     or, naturally, simple paragraphs.
 
+[^sphinx-of-black-quartz_judge-my-vow]: This works.
+
 [^unused]: This is unused.
 .
 <p>This is some text!<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup>. Other text.<sup class="footnote-ref"><a href="#fn2" id="fnref2">2</a></sup>.</p>
 <p>Here's a thing<sup class="footnote-ref"><a href="#fn3" id="fnref3">3</a></sup>.</p>
-<p>And another thing<sup class="footnote-ref"><a href="#fn4" id="fnref4">4</a></sup>.</p>
+<p>And another thing<sup class="footnote-ref"><a href="#fn4" id="fnref4">4</a></sup>. Footnotes can use lots of different characters.<sup class="footnote-ref"><a href="#fn5" id="fnref5">5</a></sup></p>
 <p>This doesn't have a referent[^nope].</p>
 <p>Hi!</p>
 <section class="footnotes">
@@ -697,6 +699,9 @@ Hi!
 <pre><code>this is now a code block (8 spaces indentation)
 </code></pre>
 <a href="#fnref4" class="footnote-backref">↩</a>
+</li>
+<li id="fn5">
+<p>This works. <a href="#fnref5" class="footnote-backref">↩</a></p>
 </li>
 </ol>
 </section>

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -649,7 +649,7 @@ This is some text![^1]. Other text.[^footnote].
 
 Here's a thing[^other-note].
 
-And another thing[^codeblock-note]. Footnotes can use lots of different characters.[^sphinx-of-black-quartz_judge-my-vow]
+And another thing[^codeblock-note]. Footnotes can use lots of different characters.[^sphinx-of-black-quartz_judge-my-vow-0123456789]
 
 This doesn't have a referent[^nope].
 
@@ -670,7 +670,7 @@ Hi!
 
     or, naturally, simple paragraphs.
 
-[^sphinx-of-black-quartz_judge-my-vow]: This works.
+[^sphinx-of-black-quartz_judge-my-vow-0123456789]: This works.
 
 [^unused]: This is unused.
 .


### PR DESCRIPTION
Superseeded by https://github.com/github/cmark-gfm/pull/229. 

---
Ideally, this PR closes https://github.com/github/cmark-gfm/issues/121

As noted in https://github.com/github/cmark-gfm/issues/121, when the autolink extension and the footnotes extension are both turned on, `cmark-gfm` fails to correctly process footnotes whose reference label contains the character `w` or `_` in it.

This PR resolves this by ignoring nodes that occur after `[`, and `^`, and just copying the text between the `^` and the `]` for use as our footnote reference label.

### Why?
In practice, this occurs because when we parse the text for footnote references we assumed that there weren't any nodes in between the '[' character and the rest of the `^footnote]` label.

I did not investigate the autolinker, but this is what I suspect was happening:
- The parser inspects any given line of markdown character by character
- Upon seeing the opening brace `[`, we cut a new text node, and insert it into the parser's AST
- Upon seeing the closing brace `]`, we look back and try to match the previous characters into a link, or some markdown feature. If nothing else matches, we try to look for a footnote reference.
- Before we reach the closing brace `]`, the autolinker greedily looks for `_` or `w` and I think a few other characters while trying to guess if it's a URL. Upon finding a `w`, it inserts a new text node in the hopes that it might find a `www.foo.com` url as it keeps parsing.

Given the following input:

```markdown
Hello world.[^what-a-world]

[^what-a-world]: example.
```

The footnote reference code expected to see the following nodes in the parser: `Hello world.`, `[`, `^what-a-world]`

but instead it saw: `Hello world.`, `[`, `^` `what-a-`, `world]`.

Because this parser is operating one character at a time, and it is being called at the `close_bracket`, if we've found that we're dealing with a footnote reference then it should be safe to disregard any additional nodes in the AST, because by definition they would not occur _after_ the closing bracket.