### PR TITLE
cmark-gfm-core-extensions: use stdbool.h instead of private header

### DIFF
--- a/extensions/cmark-gfm-core-extensions.h
+++ b/extensions/cmark-gfm-core-extensions.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include "cmark-gfm-extension_api.h"
 #include "cmark-gfm-extensions_export.h"
-#include "config.h" // for bool
+#include <stdbool.h>
 #include <stdint.h>
 
 CMARK_GFM_EXTENSIONS_EXPORT


### PR DESCRIPTION
fixes #244