### PR TITLE
Allow table marker row to have more columns than header

### DIFF
--- a/extensions/table.c
+++ b/extensions/table.c
@@ -251,7 +251,7 @@ static cmark_node *try_opening_table_header(cmark_syntax_extension *self,
   parent_string = cmark_node_get_string_content(parent_container);
   header_row = row_from_string(self, parser, (unsigned char *)parent_string,
                                (int)strlen(parent_string));
-  if (!header_row || header_row->n_columns != marker_row->n_columns) {
+  if (!header_row || header_row->n_columns > marker_row->n_columns) {
     free_table_row(parser->mem, marker_row);
     free_table_row(parser->mem, header_row);
     cmark_arena_pop();
@@ -282,7 +282,7 @@ static cmark_node *try_opening_table_header(cmark_syntax_extension *self,
   set_n_table_columns(parent_container, header_row->n_columns);
 
   uint8_t *alignments =
-      (uint8_t *)parser->mem->calloc(header_row->n_columns, sizeof(uint8_t));
+      (uint8_t *)parser->mem->calloc(marker_row->n_columns, sizeof(uint8_t));
   cmark_llist *it = marker_row->cells;
   for (i = 0; it; it = it->next, ++i) {
     node_cell *node = (node_cell *)it->data;


### PR DESCRIPTION
To match with Reddit's more lax table header/marker syntax (the header being the first row, and the marker row being the row after it that dictates the alignments), this change allows more marker/alignment columns than header columns.

For whatever reason this behavior/syntax is very common on Reddit, I assume because some folks will just edit the header row to remove a column, and then simply not update the alignment/marker row.

For instance this syntax renders a table on Reddit with 3 columns, but does not render with cmark-gfm as it has one too many marker/alignment columns:

markdown
```
|Header1|Header2|Header3|
|-------|-------|-------|-------|
| Body1 | Body2 | Body 3|
```

But *does* render on Reddit as if the last marker/alignment column wasn't present, thus looking like this:

|Header1|Header2|Header3|
|-------|-------|-------|
| Body1 | Body2 | Body 3|

This PR changes the rules of the table extension to allow more marker/alignment columns than header columns.

It's a seemingly harmless change and all tests still pass. Note that the opposite (more header columns than marker/alignment columns) *would* fail the tests understandably as some header columns would not have an explicit alignment set. 

I totally understand if this isn't behavior you're interested in/care about, I just integrated it into my app and appreciate this library and thus wanted to do the good thing and offer up my work in case you were interested!

(Shoutout to @QuietMisdreavus for helping me, any nice parts of this PR are thanks to her, and any mistakes are totally my fault.)