### PR TITLE
Expose `cmark_node_parent_footnote_def`.

### DIFF
--- a/src/cmark-gfm.h
+++ b/src/cmark-gfm.h
@@ -225,6 +225,11 @@ CMARK_GFM_EXPORT cmark_node *cmark_node_first_child(cmark_node *node);
  */
 CMARK_GFM_EXPORT cmark_node *cmark_node_last_child(cmark_node *node);
 
+/** Returns the footnote reference of 'node', or NULL if 'node' doesn't have a
+  * footnote reference.
+ */
+CMARK_GFM_EXPORT cmark_node *cmark_node_parent_footnote_def(cmark_node *node);
+
 /**
  * ## Iterator
  *

--- a/src/cmark-gfm.h
+++ b/src/cmark-gfm.h
@@ -226,7 +226,7 @@ CMARK_GFM_EXPORT cmark_node *cmark_node_first_child(cmark_node *node);
 CMARK_GFM_EXPORT cmark_node *cmark_node_last_child(cmark_node *node);
 
 /** Returns the footnote reference of 'node', or NULL if 'node' doesn't have a
-  * footnote reference.
+ * footnote reference.
  */
 CMARK_GFM_EXPORT cmark_node *cmark_node_parent_footnote_def(cmark_node *node);
 

--- a/src/node.c
+++ b/src/node.c
@@ -301,6 +301,14 @@ cmark_node *cmark_node_last_child(cmark_node *node) {
   }
 }
 
+cmark_node *cmark_node_parent_footnote_def(cmark_node *node) {
+  if (node == NULL) {
+    return NULL;
+  } else {
+    return node->parent_footnote_def;
+  }
+}
+
 void *cmark_node_get_user_data(cmark_node *node) {
   if (node == NULL) {
     return NULL;


### PR DESCRIPTION
@phillmv in https://github.com/ioquatix/cmark-gfm/commit/17170400954862dc0a626ae7467aaef6f6f78448 you introduced a better internal representation for footnotes.

I maintain a fork/interface for Ruby.

We cannot generate the same footnotes as the internal HTML renderer because the public interface doesn't expose all the required details.

This is an attempt to start a discussion around what that interface should look like.

- There are no tests - should we add some?
- The interface `cmark_node_parent_footnote_def` seems clunky - what is `_def` and should this really be part of the name?