### PR TITLE
Normalize nomenclature: marker row vs. delimiter row

### DIFF
--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -208,7 +208,7 @@ fff | ggg | hhh | iii | jjj
 
 ### Table cell count mismatches
 
-The header and marker row must match.
+The header and delimiter row must match.
 
 ```````````````````````````````` example
 | a | b | c |


### PR DESCRIPTION
The code for the table extension used the term "marker row" for the line separating a table header from the body, but the spec calls it ["delimiter row"](https://github.github.com/gfm/#delimiter-row). This change normalizes the terminology in the code so that it's consistent with the spec.

This PR addresses issue #269.