### PR TITLE
Compare integers of same signedness

### DIFF
--- a/extensions/autolink.c
+++ b/extensions/autolink.c
@@ -273,7 +273,7 @@ static bool validate_protocol(char protocol[], uint8_t *data, int rewind) {
   size_t len = strlen(protocol);
 
   // Check that the protocol matches
-  for (int i = 1; i <= len; i++) {
+  for (size_t i = 1; i <= len; i++) {
     if (data[-rewind - i] != protocol[len - i]) {
       return false;
     }


### PR DESCRIPTION
When `i` is an `int`, we get a warning when building:

```
../subprojects/cmark-gfm-0.29.0.gfm.6/extensions/autolink.c:276:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  276 |   for (int i = 1; i <= len; i++) {
```

This is fixed by using `size_t` as the type for `i`, which is the same type as `len`.