### PR TITLE
Add test for domains with underscores and fix roundtrip behavior

### DIFF
--- a/extensions/autolink.c
+++ b/extensions/autolink.c
@@ -116,7 +116,20 @@ static size_t autolink_delim(uint8_t *data, size_t link_end) {
 static size_t check_domain(uint8_t *data, size_t size, int allow_short) {
   size_t i, np = 0, uscore1 = 0, uscore2 = 0;
 
+  /* The purpose of this code is to reject urls that contain an underscore
+   * in one of the last two segments. Examples:
+   *
+   *   www.xxx.yyy.zzz     autolinked
+   *   www.xxx.yyy._zzz    not autolinked
+   *   www.xxx._yyy.zzz    not autolinked
+   *   www._xxx.yyy.zzz    autolinked
+   *
+   * The reason is that domain names are allowed to include underscores,
+   * but host names are not. See: https://stackoverflow.com/a/2183140
+   */
   for (i = 1; i < size - 1; i++) {
+    if (data[i] == '\\' && i < size - 2)
+      i++;
     if (data[i] == '_')
       uscore2++;
     else if (data[i] == '.') {

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -581,6 +581,12 @@ www.github.com www.github.com/á
 
 www.google.com/a_b
 
+Underscores not allowed in host name www.xxx.yyy._zzz
+
+Underscores not allowed in host name www.xxx._yyy.zzz
+
+Underscores allowed in domain name www._xxx.yyy.zzz
+
 **Autolink and http://inlines**
 
 ![http://inline.com/image](http://inline.com/image)
@@ -618,6 +624,9 @@ http://🍄.ga/ http://x🍄.ga/
 <p>Email me at:<a href="mailto:scyther@pokemon.com">scyther@pokemon.com</a></p>
 <p><a href="http://www.github.com">www.github.com</a> <a href="http://www.github.com/%C3%A1">www.github.com/á</a></p>
 <p><a href="http://www.google.com/a_b">www.google.com/a_b</a></p>
+<p>Underscores not allowed in host name www.xxx.yyy._zzz</p>
+<p>Underscores not allowed in host name www.xxx._yyy.zzz</p>
+<p>Underscores allowed in domain name <a href="http://www._xxx.yyy.zzz">www._xxx.yyy.zzz</a></p>
 <p><strong>Autolink and <a href="http://inlines">http://inlines</a></strong></p>
 <p><img src="http://inline.com/image" alt="http://inline.com/image" /></p>
 <p><a href="mailto:a.w@b.c">a.w@b.c</a></p>


### PR DESCRIPTION
Add a test for the underscore logic in `check_domain` in the autolink extension.

I had to make a minor change to the code to get the "roundtrip" test to pass. The roundtrip test checks that converting to commonmark first and then to html gives the same result as converting directly to html. The first step converts the underscore to `\_` which gets handled differently by the logic in `check_domain`. Adding some code to skip the `\` character fixes it.