### PR TITLE
Use up-to-date clang-format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION?=$(SPECVERSION)
 RELEASE?=CommonMark-$(VERSION)
 INSTALL_PREFIX?=/usr/local
 CLANG_CHECK?=clang-check
-CLANG_FORMAT=clang-format-3.5 -style llvm -sort-includes=0 -i
+CLANG_FORMAT=clang-format -style llvm -sort-includes=0 -i
 AFL_PATH?=/usr/local/bin
 
 .PHONY: all cmake_build leakcheck clean fuzztest test debug ubsan asan mingw archive newbench bench format update-spec afl clang-check docker libFuzzer
@@ -140,7 +140,7 @@ $(EXTDIR)/ext_scanners.c: $(EXTDIR)/ext_scanners.re
 	esac
 	re2c --case-insensitive -b -i --no-generation-date -8 \
 		--encoding-policy substitute -o $@ $<
-	clang-format-3.5 -style llvm -i $@
+	clang-format -style llvm -i $@
 
 # We include entities.inc in the repository, so normally this
 # doesn't need to be regenerated:
@@ -211,7 +211,7 @@ format:
 	$(CLANG_FORMAT) src/*.c src/*.h api_test/*.c api_test/*.h
 
 format-extensions:
-	clang-format-3.5 -style llvm -i extensions/*.c extensions/*.h
+	clang-format -style llvm -i extensions/*.c extensions/*.h
 
 operf: $(CMARK)
 	operf $< < $(BENCHFILE) > /dev/null

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
   wget \
   clang \
   man \
-  clang-format-3.5 \
+  clang-format \
   && apt-get clean
 
 RUN wget http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz && \


### PR DESCRIPTION
The `Makefile` refers to a very old version of clang-format, which means that I get an error when I try to run `make format`. I think it's better to remove the version number and just use whichever version is currently installed.