### PR TITLE
Fix sign comparison warning at compile

### DIFF
--- a/extensions/autolink.c
+++ b/extensions/autolink.c
@@ -273,7 +273,7 @@ static bool validate_protocol(char protocol[], uint8_t *data, int rewind) {
   size_t len = strlen(protocol);
 
   // Check that the protocol matches
-  for (int i = 1; i <= len; i++) {
+  for (size_t i = 1; i <= len; i++) {
     if (data[-rewind - i] != protocol[len - i]) {
       return false;
     }


### PR DESCRIPTION
The warning:

    cmark-gfm/extensions/autolink.c:276:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
      276 |   for (int i = 1; i <= len; i++) {
          |

There's no harm that can be done here, since `len` is the `strlen` of the first argument to this function, which is a fixed set of (short) strings:

    $ git grep 'validate_protocol'
    extensions/autolink.c:static bool validate_protocol(char protocol[], uint8_t *data, int rewind) {
    extensions/autolink.c:      if (validate_protocol("mailto:", data, rewind)) {
    extensions/autolink.c:      if (validate_protocol("xmpp:", data, rewind)) {

but I think it's nice to have a clean build output (and helps avoid the risk of developers becoming desensitized to warnings), and the cost of a couple of extra bytes for `size_t` over `int` is trivial.