### PR TITLE
Prevent implicit integer truncations

### DIFF
--- a/extensions/autolink.c
+++ b/extensions/autolink.c
@@ -2,19 +2,12 @@
 #include <parser.h>
 #include <string.h>
 #include <utf8.h>
+#include <stddef.h>
 
 #if defined(_WIN32)
 #define strncasecmp _strnicmp
 #else
 #include <strings.h>
-#endif
-
-// for ssize_t
-#ifdef _MSC_VER
-#include <BaseTsd.h>
-typedef SSIZE_T ssize_t;
-#else
-#include <unistd.h>
 #endif
 
 static int is_valid_hostchar(const uint8_t *link, size_t link_len) {
@@ -314,7 +307,7 @@ static bool validate_protocol(char protocol[], uint8_t *data, size_t rewind, siz
     return true;
   }
 
-  char prev_char = data[-((ssize_t)rewind) - len - 1];
+  char prev_char = data[-((ptrdiff_t)rewind) - len - 1];
 
   // Make sure the character before the protocol is non-alphanumeric
   return !cmark_isalnum(prev_char);

--- a/extensions/table.c
+++ b/extensions/table.c
@@ -133,7 +133,7 @@ static node_cell* append_row_cell(cmark_mem *mem, table_row *row) {
     // Use realloc to double the size of the buffer.
     row->cells = (node_cell *)mem->realloc(row->cells, (2 * n_columns - 1) * sizeof(node_cell));
   }
-  row->n_columns = n_columns;
+  row->n_columns = (uint16_t)n_columns;
   return &row->cells[n_columns-1];
 }
 

--- a/src/map.c
+++ b/src/map.c
@@ -51,7 +51,7 @@ refsearch(const void *label, const void *p2) {
 }
 
 static void sort_map(cmark_map *map) {
-  unsigned int i = 0, last = 0, size = map->size;
+  size_t i = 0, last = 0, size = map->size;
   cmark_map_entry *r = map->refs, **sorted = NULL;
 
   sorted = (cmark_map_entry **)map->mem->calloc(size, sizeof(cmark_map_entry *));

--- a/src/map.h
+++ b/src/map.h
@@ -10,8 +10,8 @@ extern "C" {
 struct cmark_map_entry {
   struct cmark_map_entry *next;
   unsigned char *label;
-  unsigned int age;
-  unsigned int size;
+  size_t age;
+  size_t size;
 };
 
 typedef struct cmark_map_entry cmark_map_entry;
@@ -24,9 +24,9 @@ struct cmark_map {
   cmark_mem *mem;
   cmark_map_entry *refs;
   cmark_map_entry **sorted;
-  unsigned int size;
-  unsigned int ref_size;
-  unsigned int max_ref_size;
+  size_t size;
+  size_t ref_size;
+  size_t max_ref_size;
   cmark_map_free_f free;
 };
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -46,7 +46,7 @@ struct cmark_parser {
   /* Options set by the user, see the Options section in cmark.h */
   int options;
   bool last_buffer_ended_with_cr;
-  unsigned int total_size;
+  size_t total_size;
   cmark_llist *syntax_extensions;
   cmark_llist *inline_syntax_extensions;
   cmark_ispunct_func backslash_ispunct;


### PR DESCRIPTION
This commit changes size integers to consistently be of type size_t to prevent implicit integer truncations during integer arithmetic.

What remain are explicit truncations to (bufsize_t) which is of type int32_t. This requires additional careful consideration.