### PR TITLE
Deprecate cmark_init_standard_node_flags

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -1133,7 +1133,6 @@ int main() {
   int retval;
   test_batch_runner *runner = test_batch_runner_new();
 
-  cmark_init_standard_node_flags();
   version(runner);
   constructor(runner);
   accessors(runner);

--- a/extensions/table.c
+++ b/extensions/table.c
@@ -12,7 +12,7 @@
 #include "cmark-gfm-core-extensions.h"
 
 // Custom node flag, initialized in `create_table_extension`.
-static cmark_node__internal_flags CMARK_NODE__TABLE_VISITED;
+static cmark_node_internal_flags CMARK_NODE__TABLE_VISITED;
 
 cmark_node_type CMARK_NODE_TABLE, CMARK_NODE_TABLE_ROW,
     CMARK_NODE_TABLE_CELL;

--- a/fuzz/fuzz_quadratic.c
+++ b/fuzz/fuzz_quadratic.c
@@ -17,7 +17,6 @@ const char *extension_names[] = {
 };
 
 int LLVMFuzzerInitialize(int *argc, char ***argv) {
-  cmark_init_standard_node_flags();
   cmark_gfm_core_extensions_ensure_registered();
   return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -139,7 +139,6 @@ int main(int argc, char *argv[]) {
   }
 #endif
 
-  cmark_init_standard_node_flags();
   cmark_gfm_core_extensions_ensure_registered();
 
 #ifdef USE_PLEDGE

--- a/src/node.c
+++ b/src/node.c
@@ -9,12 +9,8 @@ static void S_node_unlink(cmark_node *node);
 
 #define NODE_MEM(node) cmark_node_mem(node)
 
-cmark_node__internal_flags CMARK_NODE__OPEN;
-cmark_node__internal_flags CMARK_NODE__LAST_LINE_BLANK;
-cmark_node__internal_flags CMARK_NODE__LAST_LINE_CHECKED;
-
-void cmark_register_node_flag(cmark_node__internal_flags *flags) {
-  static uint8_t shift = 0;
+void cmark_register_node_flag(cmark_node_internal_flags *flags) {
+  static cmark_node_internal_flags nextflag = CMARK_NODE__REGISTER_FIRST;
 
   // flags should be a pointer to a global variable and this function
   // should only be called once to initialize its value.
@@ -24,24 +20,16 @@ void cmark_register_node_flag(cmark_node__internal_flags *flags) {
   }
 
   // Check that we haven't run out of bits.
-  if (shift >= 8 * sizeof(cmark_node__internal_flags)) {
+  if (nextflag == 0) {
     fprintf(stderr, "too many flags in cmark_register_node_flag\n");
     abort();
   }
 
-  *flags = (cmark_node__internal_flags)1 << shift;
-  shift++;
+  *flags = nextflag;
+  nextflag <<= 1;
 }
 
-void cmark_init_standard_node_flags() {
-  static int initialized = 0;
-  if (!initialized) {
-    initialized = 1;
-    cmark_register_node_flag(&CMARK_NODE__OPEN);
-    cmark_register_node_flag(&CMARK_NODE__LAST_LINE_BLANK);
-    cmark_register_node_flag(&CMARK_NODE__LAST_LINE_CHECKED);
-  }
-}
+void cmark_init_standard_node_flags() {}
 
 bool cmark_node_can_contain_type(cmark_node *node, cmark_node_type child_type) {
   if (child_type == CMARK_NODE_DOCUMENT) {

--- a/src/node.h
+++ b/src/node.h
@@ -48,7 +48,17 @@ typedef struct {
   cmark_chunk on_exit;
 } cmark_custom;
 
-typedef uint16_t cmark_node__internal_flags;
+enum cmark_node__internal_flags {
+  CMARK_NODE__OPEN = (1 << 0),
+  CMARK_NODE__LAST_LINE_BLANK = (1 << 1),
+  CMARK_NODE__LAST_LINE_CHECKED = (1 << 2),
+
+  // Extensions can register custom flags by calling `cmark_register_node_flag`.
+  // This is the starting value for the custom flags.
+  CMARK_NODE__REGISTER_FIRST = (1 << 3),
+};
+
+typedef uint16_t cmark_node_internal_flags;
 
 struct cmark_node {
   cmark_strbuf content;
@@ -68,7 +78,7 @@ struct cmark_node {
   int end_column;
   int internal_offset;
   uint16_t type;
-  cmark_node__internal_flags flags;
+  cmark_node_internal_flags flags;
 
   cmark_syntax_extension *extension;
 
@@ -98,19 +108,15 @@ struct cmark_node {
  * which will store the flag value.
  */
 CMARK_GFM_EXPORT
-void cmark_register_node_flag(cmark_node__internal_flags *flags);
+void cmark_register_node_flag(cmark_node_internal_flags *flags);
 
 /**
- * Standard node flags. (Initialized using `cmark_init_standard_node_flags`.)
- */
-extern cmark_node__internal_flags CMARK_NODE__OPEN;
-extern cmark_node__internal_flags CMARK_NODE__LAST_LINE_BLANK;
-extern cmark_node__internal_flags CMARK_NODE__LAST_LINE_CHECKED;
-
-/**
- * Uses `cmark_register_node_flag` to initialize the standard node flags.
- * This function should be called at program startup time. Calling it
- * multiple times has no additional effect.
+ * DEPRECATED.
+ *
+ * This function was added in cmark-gfm version 0.29.0.gfm.7, and was
+ * required to be called at program start time, which caused
+ * backwards-compatibility issues in applications that use cmark-gfm as a
+ * library. It is now a no-op.
  */
 CMARK_GFM_EXPORT
 void cmark_init_standard_node_flags();

--- a/test/cmark.py
+++ b/test/cmark.py
@@ -13,7 +13,6 @@ def pipe_through_prog(prog, text):
 
 def parse(lib, extlib, text, extensions):
     cmark_gfm_core_extensions_ensure_registered = extlib.cmark_gfm_core_extensions_ensure_registered
-    cmark_init_standard_node_flags = lib.cmark_init_standard_node_flags
 
     find_syntax_extension = lib.cmark_find_syntax_extension
     find_syntax_extension.restype = c_void_p
@@ -33,7 +32,6 @@ def parse(lib, extlib, text, extensions):
     parser_finish.restype = c_void_p
     parser_finish.argtypes = [c_void_p]
 
-    cmark_init_standard_node_flags()
     cmark_gfm_core_extensions_ensure_registered()
 
     parser = parser_new(0)


### PR DESCRIPTION
Fixes: #303

I added `cmark_init_standard_node_flags()` in https://github.com/github/cmark-gfm/commit/420c20a112acd75af463d8930d8d59f2d25e9cd5, but it was a mistake because it caused backwards-compatibility issues for clients who use cmark-gfm as a library.