### PR TITLE
Fix cmake warnings

### DIFF
--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
 set(LIBRARY "libcmark-gfm-extensions")
 set(STATICLIBRARY "libcmark-gfm-extensions_static")
 set(LIBRARY_SOURCES
@@ -24,7 +23,6 @@ include_directories(. ${CMAKE_CURRENT_BINARY_DIR})
 
 set(CMAKE_C_FLAGS_PROFILE "${CMAKE_C_FLAGS_RELEASE} -pg")
 set(CMAKE_LINKER_PROFILE "${CMAKE_LINKER_FLAGS_RELEASE} -pg")
-add_compiler_export_flags()
 
 if (CMARK_SHARED)
   add_library(${LIBRARY} SHARED ${LIBRARY_SOURCES})


### PR DESCRIPTION
Remove two redundant lines from `extensions/CMakeLists.txt` which were causing warnings.