### PR TITLE
fix: Links with unique targets should have unique labels

### DIFF
--- a/src/html.c
+++ b/src/html.c
@@ -63,11 +63,13 @@ static bool S_put_footnote_backref(cmark_html_renderer *renderer, cmark_strbuf *
   if (renderer->written_footnote_ix >= renderer->footnote_ix)
     return false;
   renderer->written_footnote_ix = renderer->footnote_ix;
-
+  char m[32];
+  snprintf(m, sizeof(m), "%d", renderer->written_footnote_ix);
+  
   cmark_strbuf_puts(html, "<a href=\"#fnref-");
   houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
   cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to reference ");
-  houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
+  cmark_strbuf_puts(html, m);
   cmark_strbuf_puts(html, "\">↩</a>");
 
   if (node->footnote.def_count > 1)

--- a/src/html.c
+++ b/src/html.c
@@ -68,7 +68,9 @@ static bool S_put_footnote_backref(cmark_html_renderer *renderer, cmark_strbuf *
 
   cmark_strbuf_puts(html, "<a href=\"#fnref-");
   houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
-  cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to reference ");
+  cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"");
+  cmark_strbuf_puts(html, m);
+  cmark_strbuf_puts(html, "\" aria-label=\"Back to reference ");
   cmark_strbuf_puts(html, m);
   cmark_strbuf_puts(html, "\">↩</a>");
 
@@ -82,7 +84,11 @@ static bool S_put_footnote_backref(cmark_html_renderer *renderer, cmark_strbuf *
       houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
       cmark_strbuf_puts(html, "-");
       cmark_strbuf_puts(html, n);
-      cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to reference ");
+      cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"");
+      cmark_strbuf_puts(html, m);
+      cmark_strbuf_puts(html, "-");
+      cmark_strbuf_puts(html, n);
+      cmark_strbuf_puts(html, "\" aria-label=\"Back to reference ");
       cmark_strbuf_puts(html, m);
       cmark_strbuf_puts(html, "-");
       cmark_strbuf_puts(html, n);

--- a/src/html.c
+++ b/src/html.c
@@ -65,7 +65,7 @@ static bool S_put_footnote_backref(cmark_html_renderer *renderer, cmark_strbuf *
   renderer->written_footnote_ix = renderer->footnote_ix;
   char m[32];
   snprintf(m, sizeof(m), "%d", renderer->written_footnote_ix);
-  
+
   cmark_strbuf_puts(html, "<a href=\"#fnref-");
   houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
   cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to reference ");
@@ -83,7 +83,7 @@ static bool S_put_footnote_backref(cmark_html_renderer *renderer, cmark_strbuf *
       cmark_strbuf_puts(html, "-");
       cmark_strbuf_puts(html, n);
       cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to reference ");
-      houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
+      cmark_strbuf_puts(html, m);
       cmark_strbuf_puts(html, "-");
       cmark_strbuf_puts(html, n);
       cmark_strbuf_puts(html, "\">↩<sup class=\"footnote-ref\">");

--- a/src/html.c
+++ b/src/html.c
@@ -66,7 +66,9 @@ static bool S_put_footnote_backref(cmark_html_renderer *renderer, cmark_strbuf *
 
   cmark_strbuf_puts(html, "<a href=\"#fnref-");
   houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
-  cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a>");
+  cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to reference ");
+  houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
+  cmark_strbuf_puts(html, "\">↩</a>");
 
   if (node->footnote.def_count > 1)
   {
@@ -78,7 +80,11 @@ static bool S_put_footnote_backref(cmark_html_renderer *renderer, cmark_strbuf *
       houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
       cmark_strbuf_puts(html, "-");
       cmark_strbuf_puts(html, n);
-      cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩<sup class=\"footnote-ref\">");
+      cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to reference ");
+      houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
+      cmark_strbuf_puts(html, "-");
+      cmark_strbuf_puts(html, n);
+      cmark_strbuf_puts(html, "\">↩<sup class=\"footnote-ref\">");
       cmark_strbuf_puts(html, n);
       cmark_strbuf_puts(html, "</sup></a>");
     }

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -737,7 +737,7 @@ Hi!
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-1">
-<p>Some <em>bolded</em> footnote definition. <a href="#fnref-1" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a></p>
+<p>Some <em>bolded</em> footnote definition. <a href="#fnref-1" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a></p>
 </li>
 <li id="fn-footnote">
 <blockquote>
@@ -745,15 +745,15 @@ Hi!
 </blockquote>
 <pre><code>as well as code blocks
 </code></pre>
-<p>or, naturally, simple paragraphs. <a href="#fnref-footnote" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a></p>
+<p>or, naturally, simple paragraphs. <a href="#fnref-footnote" class="footnote-backref" data-footnote-backref aria-label="Back to reference 2">↩</a></p>
 </li>
 <li id="fn-other-note">
-<p>no code block here (spaces are stripped away) <a href="#fnref-other-note" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a></p>
+<p>no code block here (spaces are stripped away) <a href="#fnref-other-note" class="footnote-backref" data-footnote-backref aria-label="Back to reference 3">↩</a></p>
 </li>
 <li id="fn-codeblock-note">
 <pre><code>this is now a code block (8 spaces indentation)
 </code></pre>
-<a href="#fnref-codeblock-note" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a>
+<a href="#fnref-codeblock-note" class="footnote-backref" data-footnote-backref aria-label="Back to reference 4">↩</a>
 </li>
 </ol>
 </section>
@@ -773,7 +773,7 @@ This footnote is referenced[^a-footnote] multiple times, in lots of different pl
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-a-footnote">
-<p>This footnote definition should have three backrefs. <a href="#fnref-a-footnote" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a> <a href="#fnref-a-footnote-2" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩<sup class="footnote-ref">2</sup></a> <a href="#fnref-a-footnote-3" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩<sup class="footnote-ref">3</sup></a></p>
+<p>This footnote definition should have three backrefs. <a href="#fnref-a-footnote" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a> <a href="#fnref-a-footnote-2" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1-2">↩<sup class="footnote-ref">2</sup></a> <a href="#fnref-a-footnote-3" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1-3">↩<sup class="footnote-ref">3</sup></a></p>
 </li>
 </ol>
 </section>
@@ -790,7 +790,7 @@ Hello[^"><script>alert(1)</script>]
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-%22%3E%3Cscript%3Ealert(1)%3C/script%3E">
-<p>pwned <a href="#fnref-%22%3E%3Cscript%3Ealert(1)%3C/script%3E" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a></p>
+<p>pwned <a href="#fnref-%22%3E%3Cscript%3Ealert(1)%3C/script%3E" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a></p>
 </li>
 </ol>
 </section>

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -737,7 +737,7 @@ Hi!
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-1">
-<p>Some <em>bolded</em> footnote definition. <a href="#fnref-1" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a></p>
+<p>Some <em>bolded</em> footnote definition. <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
 </li>
 <li id="fn-footnote">
 <blockquote>
@@ -745,15 +745,15 @@ Hi!
 </blockquote>
 <pre><code>as well as code blocks
 </code></pre>
-<p>or, naturally, simple paragraphs. <a href="#fnref-footnote" class="footnote-backref" data-footnote-backref aria-label="Back to reference 2">↩</a></p>
+<p>or, naturally, simple paragraphs. <a href="#fnref-footnote" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
 </li>
 <li id="fn-other-note">
-<p>no code block here (spaces are stripped away) <a href="#fnref-other-note" class="footnote-backref" data-footnote-backref aria-label="Back to reference 3">↩</a></p>
+<p>no code block here (spaces are stripped away) <a href="#fnref-other-note" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="3" aria-label="Back to reference 3">↩</a></p>
 </li>
 <li id="fn-codeblock-note">
 <pre><code>this is now a code block (8 spaces indentation)
 </code></pre>
-<a href="#fnref-codeblock-note" class="footnote-backref" data-footnote-backref aria-label="Back to reference 4">↩</a>
+<a href="#fnref-codeblock-note" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="4" aria-label="Back to reference 4">↩</a>
 </li>
 </ol>
 </section>
@@ -773,7 +773,7 @@ This footnote is referenced[^a-footnote] multiple times, in lots of different pl
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-a-footnote">
-<p>This footnote definition should have three backrefs. <a href="#fnref-a-footnote" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a> <a href="#fnref-a-footnote-2" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1-2">↩<sup class="footnote-ref">2</sup></a> <a href="#fnref-a-footnote-3" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1-3">↩<sup class="footnote-ref">3</sup></a></p>
+<p>This footnote definition should have three backrefs. <a href="#fnref-a-footnote" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a> <a href="#fnref-a-footnote-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-2" aria-label="Back to reference 1-2">↩<sup class="footnote-ref">2</sup></a> <a href="#fnref-a-footnote-3" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-3" aria-label="Back to reference 1-3">↩<sup class="footnote-ref">3</sup></a></p>
 </li>
 </ol>
 </section>
@@ -790,7 +790,7 @@ Hello[^"><script>alert(1)</script>]
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-%22%3E%3Cscript%3Ealert(1)%3C/script%3E">
-<p>pwned <a href="#fnref-%22%3E%3Cscript%3Ealert(1)%3C/script%3E" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a></p>
+<p>pwned <a href="#fnref-%22%3E%3Cscript%3Ealert(1)%3C/script%3E" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
 </li>
 </ol>
 </section>

--- a/test/regression.txt
+++ b/test/regression.txt
@@ -194,7 +194,7 @@ A footnote in a paragraph[^1]
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-1">
-<p>a footnote <a href="#fnref-1" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a> <a href="#fnref-1-2" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩<sup class="footnote-ref">2</sup></a></p>
+<p>a footnote <a href="#fnref-1" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a> <a href="#fnref-1-2" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1-2">↩<sup class="footnote-ref">2</sup></a></p>
 </li>
 </ol>
 </section>
@@ -284,10 +284,10 @@ This is some text. It has a citation.[^citation]
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-citation">
-<p>This is a long winded parapgraph that also has another citation.<sup class="footnote-ref"><a href="#fn-another-citation" id="fnref-another-citation" data-footnote-ref>2</a></sup> <a href="#fnref-citation" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a></p>
+<p>This is a long winded parapgraph that also has another citation.<sup class="footnote-ref"><a href="#fn-another-citation" id="fnref-another-citation" data-footnote-ref>2</a></sup> <a href="#fnref-citation" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a></p>
 </li>
 <li id="fn-another-citation">
-<p>My second citation. <a href="#fnref-another-citation" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a></p>
+<p>My second citation. <a href="#fnref-another-citation" class="footnote-backref" data-footnote-backref aria-label="Back to reference 2">↩</a></p>
 </li>
 </ol>
 </section>
@@ -306,10 +306,10 @@ This is some text. It has two footnotes references, side-by-side without any spa
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-footnote1">
-<p>Hello. <a href="#fnref-footnote1" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a></p>
+<p>Hello. <a href="#fnref-footnote1" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a></p>
 </li>
 <li id="fn-footnote2">
-<p>Goodbye. <a href="#fnref-footnote2" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a></p>
+<p>Goodbye. <a href="#fnref-footnote2" class="footnote-backref" data-footnote-backref aria-label="Back to reference 2">↩</a></p>
 </li>
 </ol>
 </section>
@@ -331,10 +331,10 @@ It has another footnote that contains many different characters (the autolinker 
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-widely-cited">
-<p>this renders properly. <a href="#fnref-widely-cited" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a></p>
+<p>this renders properly. <a href="#fnref-widely-cited" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a></p>
 </li>
 <li id="fn-sphinx-of-black-quartz_judge-my-vow-0123456789">
-<p>so does this. <a href="#fnref-sphinx-of-black-quartz_judge-my-vow-0123456789" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a></p>
+<p>so does this. <a href="#fnref-sphinx-of-black-quartz_judge-my-vow-0123456789" class="footnote-backref" data-footnote-backref aria-label="Back to reference 2">↩</a></p>
 </li>
 </ol>
 </section>

--- a/test/regression.txt
+++ b/test/regression.txt
@@ -194,7 +194,7 @@ A footnote in a paragraph[^1]
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-1">
-<p>a footnote <a href="#fnref-1" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a> <a href="#fnref-1-2" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1-2">↩<sup class="footnote-ref">2</sup></a></p>
+<p>a footnote <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a> <a href="#fnref-1-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-2" aria-label="Back to reference 1-2">↩<sup class="footnote-ref">2</sup></a></p>
 </li>
 </ol>
 </section>
@@ -284,10 +284,10 @@ This is some text. It has a citation.[^citation]
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-citation">
-<p>This is a long winded parapgraph that also has another citation.<sup class="footnote-ref"><a href="#fn-another-citation" id="fnref-another-citation" data-footnote-ref>2</a></sup> <a href="#fnref-citation" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a></p>
+<p>This is a long winded parapgraph that also has another citation.<sup class="footnote-ref"><a href="#fn-another-citation" id="fnref-another-citation" data-footnote-ref>2</a></sup> <a href="#fnref-citation" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
 </li>
 <li id="fn-another-citation">
-<p>My second citation. <a href="#fnref-another-citation" class="footnote-backref" data-footnote-backref aria-label="Back to reference 2">↩</a></p>
+<p>My second citation. <a href="#fnref-another-citation" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
 </li>
 </ol>
 </section>
@@ -306,10 +306,10 @@ This is some text. It has two footnotes references, side-by-side without any spa
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-footnote1">
-<p>Hello. <a href="#fnref-footnote1" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a></p>
+<p>Hello. <a href="#fnref-footnote1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
 </li>
 <li id="fn-footnote2">
-<p>Goodbye. <a href="#fnref-footnote2" class="footnote-backref" data-footnote-backref aria-label="Back to reference 2">↩</a></p>
+<p>Goodbye. <a href="#fnref-footnote2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
 </li>
 </ol>
 </section>
@@ -331,10 +331,10 @@ It has another footnote that contains many different characters (the autolinker 
 <section class="footnotes" data-footnotes>
 <ol>
 <li id="fn-widely-cited">
-<p>this renders properly. <a href="#fnref-widely-cited" class="footnote-backref" data-footnote-backref aria-label="Back to reference 1">↩</a></p>
+<p>this renders properly. <a href="#fnref-widely-cited" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
 </li>
 <li id="fn-sphinx-of-black-quartz_judge-my-vow-0123456789">
-<p>so does this. <a href="#fnref-sphinx-of-black-quartz_judge-my-vow-0123456789" class="footnote-backref" data-footnote-backref aria-label="Back to reference 2">↩</a></p>
+<p>so does this. <a href="#fnref-sphinx-of-black-quartz_judge-my-vow-0123456789" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
 </li>
 </ol>
 </section>


### PR DESCRIPTION
Follow-up to #234

### Problem

Currently, every footnote backref has the same `aria-label`: “Back to content”. However, if you click several of these links, you’ll end up in several different places in the main content. “Back to content” does not sufficiently describe the links’ purpose, resulting in a failure of [WCAG 2.1 SC 2.4.4 — Link Purpose (In Context)](https://www.w3.org/TR/WCAG21/#link-purpose-in-context).

@jscholes noted this during the January 25th, 2023 Accessibility Team Office Hours ([34:29 in the recording](https://github.rewatch.com/video/mf8k156ol1aukl50-accessibility-office-hours-january-25-2023?t=2069.139) (only accessible to Hubbers)):
> The names applied to these links, “Back to content”, are pretty terrible, because if [(e.g.)] Clay had added 9 footnotes—which I'm pretty sure I've seen him do on occasion—there would be 9 “Back to content” links that all go to the same place. And so, really we need them to say something like, “Up to footnote 1”, or something.

I volunteered to follow up, in https://github.com/github/accessibility/issues/2740#issuecomment-1403828949 (only accessible to Hubbers).

### Solution

This PR updated footnote backref `aria-label`’s to uniquely match locations in the main content:
- The link back to footnote 1’s first reference is given the `aria-label`: “Back to reference 1”.
- The link back to footnote 2’s first reference is given the `aria-label`: “Back to reference 2”.
- If footnote 1 is referenced a second time, the corresponding link back is given the `aria-label`: “Back to reference 1-2”.
- If footnote 3 has a named tag (e.g. `[^note3]`), the corresponding link back is given the `aria-label`: “Back to reference 3”.

### What should reviewers focus on?

- It’s been about 10 years since I’ve worked in a C codebase, so check for (and feel free to correct) non-idiomatic C code.
- ~There’s a 50-50 chance I messed up the named tag logic; I wouldn’t be surprised if (considering the example above) I’ve inadvertently given the `aria-label`: “Back to reference note3”. I’m hoping the tests run in CI and flag this, if so.~ Update: Fixed via https://github.com/github/cmark-gfm/commit/1f30fbb2dadf13dc58894902e3b9fb0ade7e4071 and https://github.com/github/cmark-gfm/pull/307/commits/4cc55410ce1f417d96e14b332344d14e0c82bab2.
- I haven’t yet looked up how this gets shipped to production. I’ll look that up those “next steps”, while I wait for reviews/approvals here.