### PR TITLE
Fix strict prototype clang warning

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -29,7 +29,7 @@ void cmark_register_node_flag(cmark_node_internal_flags *flags) {
   nextflag <<= 1;
 }
 
-void cmark_init_standard_node_flags() {}
+void cmark_init_standard_node_flags(void) {}
 
 bool cmark_node_can_contain_type(cmark_node *node, cmark_node_type child_type) {
   if (child_type == CMARK_NODE_DOCUMENT) {

--- a/src/node.h
+++ b/src/node.h
@@ -119,7 +119,7 @@ void cmark_register_node_flag(cmark_node_internal_flags *flags);
  * library. It is now a no-op.
  */
 CMARK_GFM_EXPORT
-void cmark_init_standard_node_flags();
+void cmark_init_standard_node_flags(void);
 
 static CMARK_INLINE cmark_mem *cmark_node_mem(cmark_node *node) {
   return node->content.mem;


### PR DESCRIPTION
cmark-gfm/src/node.h:122:36: warning: this function declaration is not a prototype [-Wstrict-prototypes] void cmark_init_standard_node_flags();
                                   ^
                                    void
1 warning generated.