### PR TITLE
commonmark, plaintext: only increment list number once per item

### DIFF
--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -223,7 +223,10 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
     if (cmark_node_get_list_type(node->parent) == CMARK_BULLET_LIST) {
       marker_width = 4;
     } else {
-      list_number = renderer->list_number++;
+      list_number = renderer->list_number;
+      if (entering) {
+        ++renderer->list_number;
+      }
       list_delim = cmark_node_get_list_delim(node->parent);
       // we ensure a width of at least 4 so
       // we get nice transition from single digits

--- a/src/plaintext.c
+++ b/src/plaintext.c
@@ -68,7 +68,10 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
     if (cmark_node_get_list_type(node->parent) == CMARK_BULLET_LIST) {
       marker_width = 4;
     } else {
-      list_number = renderer->list_number++;
+      list_number = renderer->list_number;
+      if (entering) {
+        ++renderer->list_number;
+      }
       list_delim = cmark_node_get_list_delim(node->parent);
       // we ensure a width of at least 4 so
       // we get nice transition from single digits


### PR DESCRIPTION
Fixes double-increment issue from https://github.com/github/cmark-gfm/commit/763587e8775350b8cb4a2aa0f4cec3685aa96e8b. See https://github.com/gjtorikian/commonmarker/pull/236#issuecomment-1492851329.