### PR TITLE
Fix quadratic list indexing in commonmark/man/plaintext output formats

### DIFF
--- a/src/cmark-gfm.h
+++ b/src/cmark-gfm.h
@@ -423,6 +423,17 @@ CMARK_GFM_EXPORT int cmark_node_get_list_tight(cmark_node *node);
  */
 CMARK_GFM_EXPORT int cmark_node_set_list_tight(cmark_node *node, int tight);
 
+/**
+ * Returns item index of 'node'. This is only used when rendering output
+ * formats such as commonmark, which need to output the index. It is not
+ * required for formats such as html or latex.
+ */
+CMARK_GFM_EXPORT int cmark_node_get_item_index(cmark_node *node);
+
+/** Sets item index of 'node'. Returns 1 on success, 0 on failure.
+ */
+CMARK_GFM_EXPORT int cmark_node_set_item_index(cmark_node *node, int idx);
+
 /** Returns the info string from a fenced code block.
  */
 CMARK_GFM_EXPORT const char *cmark_node_get_fence_info(cmark_node *node);

--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -155,6 +155,7 @@ static bool is_autolink(cmark_node *node) {
 
 static int S_render_node(cmark_renderer *renderer, cmark_node *node,
                          cmark_event_type ev_type, int options) {
+  cmark_node *tmp;
   int list_number;
   cmark_delim_type list_delim;
   int numticks;

--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -217,15 +217,19 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       LIT("<!-- end list -->");
       BLANKLINE();
     }
-    renderer->list_number = cmark_node_get_list_start(node);
     break;
 
   case CMARK_NODE_ITEM:
     if (cmark_node_get_list_type(node->parent) == CMARK_BULLET_LIST) {
       marker_width = 4;
     } else {
-      list_number = renderer->list_number++;
+      list_number = cmark_node_get_list_start(node->parent);
       list_delim = cmark_node_get_list_delim(node->parent);
+      tmp = node;
+      while (tmp->prev) {
+        tmp = tmp->prev;
+        list_number += 1;
+      }
       // we ensure a width of at least 4 so
       // we get nice transition from single digits
       // to double

--- a/src/commonmark.c
+++ b/src/commonmark.c
@@ -155,7 +155,6 @@ static bool is_autolink(cmark_node *node) {
 
 static int S_render_node(cmark_renderer *renderer, cmark_node *node,
                          cmark_event_type ev_type, int options) {
-  cmark_node *tmp;
   int list_number;
   cmark_delim_type list_delim;
   int numticks;
@@ -223,13 +222,8 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
     if (cmark_node_get_list_type(node->parent) == CMARK_BULLET_LIST) {
       marker_width = 4;
     } else {
-      list_number = cmark_node_get_list_start(node->parent);
+      list_number = cmark_node_get_item_index(node);
       list_delim = cmark_node_get_list_delim(node->parent);
-      tmp = node;
-      while (tmp->prev) {
-        tmp = tmp->prev;
-        list_number += 1;
-      }
       // we ensure a width of at least 4 so
       // we get nice transition from single digits
       // to double

--- a/src/man.c
+++ b/src/man.c
@@ -74,7 +74,6 @@ static void S_outc(cmark_renderer *renderer, cmark_node *node,
 
 static int S_render_node(cmark_renderer *renderer, cmark_node *node,
                          cmark_event_type ev_type, int options) {
-  cmark_node *tmp;
   int list_number;
   bool entering = (ev_type == CMARK_EVENT_ENTER);
   bool allow_wrap = renderer->width > 0 && !(CMARK_OPT_NOBREAKS & options);
@@ -123,12 +122,7 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       if (cmark_node_get_list_type(node->parent) == CMARK_BULLET_LIST) {
         LIT("\\[bu] 2");
       } else {
-        list_number = cmark_node_get_list_start(node->parent);
-        tmp = node;
-        while (tmp->prev) {
-          tmp = tmp->prev;
-          list_number += 1;
-        }
+        list_number = cmark_node_get_item_index(node);
         char list_number_s[LIST_NUMBER_SIZE];
         snprintf(list_number_s, LIST_NUMBER_SIZE, "\"%d.\" 4", list_number);
         LIT(list_number_s);

--- a/src/man.c
+++ b/src/man.c
@@ -74,6 +74,7 @@ static void S_outc(cmark_renderer *renderer, cmark_node *node,
 
 static int S_render_node(cmark_renderer *renderer, cmark_node *node,
                          cmark_event_type ev_type, int options) {
+  cmark_node *tmp;
   int list_number;
   bool entering = (ev_type == CMARK_EVENT_ENTER);
   bool allow_wrap = renderer->width > 0 && !(CMARK_OPT_NOBREAKS & options);

--- a/src/man.c
+++ b/src/man.c
@@ -114,7 +114,6 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
     break;
 
   case CMARK_NODE_LIST:
-    renderer->list_number = cmark_node_get_list_start(node);
     break;
 
   case CMARK_NODE_ITEM:
@@ -124,7 +123,12 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
       if (cmark_node_get_list_type(node->parent) == CMARK_BULLET_LIST) {
         LIT("\\[bu] 2");
       } else {
-        list_number = renderer->list_number++;
+        list_number = cmark_node_get_list_start(node->parent);
+        tmp = node;
+        while (tmp->prev) {
+          tmp = tmp->prev;
+          list_number += 1;
+        }
         char list_number_s[LIST_NUMBER_SIZE];
         snprintf(list_number_s, LIST_NUMBER_SIZE, "\"%d.\" 4", list_number);
         LIT(list_number_s);

--- a/src/node.c
+++ b/src/node.c
@@ -564,6 +564,31 @@ int cmark_node_set_list_tight(cmark_node *node, int tight) {
   }
 }
 
+int cmark_node_get_item_index(cmark_node *node) {
+  if (node == NULL) {
+    return 0;
+  }
+
+  if (node->type == CMARK_NODE_ITEM) {
+    return node->as.list.start;
+  } else {
+    return 0;
+  }
+}
+
+int cmark_node_set_item_index(cmark_node *node, int idx) {
+  if (node == NULL || idx < 0) {
+    return 0;
+  }
+
+  if (node->type == CMARK_NODE_ITEM) {
+    node->as.list.start = idx;
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
 const char *cmark_node_get_fence_info(cmark_node *node) {
   if (node == NULL) {
     return NULL;

--- a/src/plaintext.c
+++ b/src/plaintext.c
@@ -18,6 +18,7 @@ static CMARK_INLINE void outc(cmark_renderer *renderer, cmark_node *node,
 
 static int S_render_node(cmark_renderer *renderer, cmark_node *node,
                          cmark_event_type ev_type, int options) {
+  cmark_node *tmp;
   int list_number;
   cmark_delim_type list_delim;
   int i;

--- a/src/plaintext.c
+++ b/src/plaintext.c
@@ -18,7 +18,6 @@ static CMARK_INLINE void outc(cmark_renderer *renderer, cmark_node *node,
 
 static int S_render_node(cmark_renderer *renderer, cmark_node *node,
                          cmark_event_type ev_type, int options) {
-  cmark_node *tmp;
   int list_number;
   cmark_delim_type list_delim;
   int i;
@@ -68,13 +67,8 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
     if (cmark_node_get_list_type(node->parent) == CMARK_BULLET_LIST) {
       marker_width = 4;
     } else {
-      list_number = cmark_node_get_list_start(node->parent);
+      list_number = cmark_node_get_item_index(node);
       list_delim = cmark_node_get_list_delim(node->parent);
-      tmp = node;
-      while (tmp->prev) {
-        tmp = tmp->prev;
-        list_number += 1;
-      }
       // we ensure a width of at least 4 so
       // we get nice transition from single digits
       // to double

--- a/src/plaintext.c
+++ b/src/plaintext.c
@@ -62,15 +62,19 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
                                     node->next->type == CMARK_NODE_LIST)) {
       CR();
     }
-    renderer->list_number = cmark_node_get_list_start(node);
     break;
 
   case CMARK_NODE_ITEM:
     if (cmark_node_get_list_type(node->parent) == CMARK_BULLET_LIST) {
       marker_width = 4;
     } else {
-      list_number = renderer->list_number++;
+      list_number = cmark_node_get_list_start(node->parent);
       list_delim = cmark_node_get_list_delim(node->parent);
+      tmp = node;
+      while (tmp->prev) {
+        tmp = tmp->prev;
+        list_number += 1;
+      }
       // we ensure a width of at least 4 so
       // we get nice transition from single digits
       // to double

--- a/src/render.c
+++ b/src/render.c
@@ -171,8 +171,8 @@ char *cmark_render(cmark_mem *mem, cmark_node *root, int options, int width,
 
   cmark_renderer renderer = {mem,   &buf, &pref, 0,           width,
                              0,     0,    true,  true,        false,
-                             false, 0,    outc,  S_cr,        S_blankline,
-                             S_out, 0};
+                             false, outc, S_cr,  S_blankline, S_out,
+                             0};
 
   while ((ev_type = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
     cur = cmark_iter_get_node(iter);

--- a/src/render.c
+++ b/src/render.c
@@ -181,6 +181,15 @@ char *cmark_render(cmark_mem *mem, cmark_node *root, int options, int width,
     } else if (cur->parent) {
       cur->ancestor_extension = cur->parent->ancestor_extension;
     }
+    if (cur->type == CMARK_NODE_ITEM) {
+      // Calculate the list item's index, for the benefit of output formats
+      // like commonmark and plaintext.
+      if (cur->prev) {
+        cmark_node_set_item_index(cur, 1 + cmark_node_get_item_index(cur->prev));
+      } else {
+        cmark_node_set_item_index(cur, cmark_node_get_list_start(cur->parent));
+      }
+    }
     if (!render_node(&renderer, cur, ev_type, options)) {
       // a false value causes us to skip processing
       // the node's contents.  this is used for

--- a/src/render.h
+++ b/src/render.h
@@ -23,7 +23,6 @@ struct cmark_renderer {
   bool begin_content;
   bool no_linebreaks;
   bool in_tight_list_item;
-  int list_number;
   void (*outc)(struct cmark_renderer *, cmark_node *, cmark_escaping, int32_t, unsigned char);
   void (*cr)(struct cmark_renderer *);
   void (*blankline)(struct cmark_renderer *);


### PR DESCRIPTION
Fixes: #321

This adds some code to `cmark_render()` to calculate the correct list item index and store it on the node, so that output formats like commonmark don't have to calculate it themselves.

Nodes of type `CMARK_NODE_ITEM` store the same kind of data as `CMARK_NODE_LIST`, as can be seen here:

https://github.com/github/cmark-gfm/blob/c4de25253b4621bef631fef3092c7d2ebd601830/src/blocks.c#L1371-L1376

So I decided to use the [`start`](https://github.com/github/cmark-gfm/blob/c4de25253b4621bef631fef3092c7d2ebd601830/src/node.h#L20) field to store the index.