### PR TITLE
Fix bug in fuzz harness

### DIFF
--- a/fuzz/fuzz_quadratic_brackets.c
+++ b/fuzz/fuzz_quadratic_brackets.c
@@ -75,9 +75,11 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
           }
           offset += fuzz_config.closelen;
         }
-        memcpy(&markdown[markdown_size], &markdown0[offset],
-               endlen);
-        markdown_size += endlen;
+        if (markdown_size + endlen <= sizeof(markdown)) {
+          memcpy(&markdown[markdown_size], &markdown0[offset],
+                 endlen);
+          markdown_size += endlen;
+        }
       } else {
         markdown_size = markdown_size0;
         memcpy(markdown, markdown0, markdown_size);


### PR DESCRIPTION
I made an embarrassing mistake in `fuzz_quadratic_brackets.c` which means that you can trigger a buffer overflow by feeding it a large file. This bug only affects the fuzzing harness, not cmark-gfm itself. To reproduce the bug:

```bash
python3 -c 'n = 0x70000; print("y" * n)' > poc.md
./fuzz/fuzz_quadratic_brackets poc.md
```