### PR TITLE
warning: passing argument 1 of ‘validate_protocol’ discards ‘const’ qualifier from pointer target type

### DIFF
--- a/extensions/autolink.c
+++ b/extensions/autolink.c
@@ -296,7 +296,7 @@ static cmark_node *match(cmark_syntax_extension *ext, cmark_parser *parser,
   // inline was finished in inlines.c.
 }
 
-static bool validate_protocol(char protocol[], uint8_t *data, size_t rewind, size_t max_rewind) {
+static bool validate_protocol(const char protocol[], uint8_t *data, size_t rewind, size_t max_rewind) {
   size_t len = strlen(protocol);
 
   if (len > (max_rewind - rewind)) {


### PR DESCRIPTION
```
../../../../ext/markly/autolink.c: In function ‘postprocess_text’:
../../../../ext/markly/autolink.c:364:31: warning: passing argument 1 of ‘validate_protocol’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  364 |         if (validate_protocol("mailto:", data + start + offset + max_rewind, rewind, max_rewind)) {
      |                               ^~~~~~~~~
../../../../ext/markly/commonmark.c: In function ‘S_render_node’:
../../../../ext/markly/autolink.c:299:36: note: expected ‘char *’ but argument is of type ‘const char *’
  299 | static bool validate_protocol(char protocol[], uint8_t *data, size_t rewind, size_t max_rewind) {
      |                               ~~~~~^~~~~~~~~~
```