### PR TITLE
Expose CMARK_NODE_FOOTNOTE_DEFINITION literal value.

### DIFF
--- a/src/blocks.c
+++ b/src/blocks.c
@@ -1220,11 +1220,12 @@ static void open_new_blocks(cmark_parser *parser, cmark_node **container,
                parser->options & CMARK_OPT_FOOTNOTES &&
                (matched = scan_footnote_definition(input, parser->first_nonspace))) {
       cmark_chunk c = cmark_chunk_dup(input, parser->first_nonspace + 2, matched - 2);
-      cmark_chunk_to_cstr(parser->mem, &c);
 
       while (c.data[c.len - 1] != ']')
         --c.len;
       --c.len;
+
+      cmark_chunk_to_cstr(parser->mem, &c);
 
       S_advance_offset(parser, input, parser->first_nonspace + matched - parser->offset, false);
       *container = add_child(parser, *container, CMARK_NODE_FOOTNOTE_DEFINITION, parser->first_nonspace + matched + 1);

--- a/src/node.c
+++ b/src/node.c
@@ -377,6 +377,7 @@ const char *cmark_node_get_literal(cmark_node *node) {
   case CMARK_NODE_HTML_INLINE:
   case CMARK_NODE_CODE:
   case CMARK_NODE_FOOTNOTE_REFERENCE:
+  case CMARK_NODE_FOOTNOTE_DEFINITION:
     return cmark_chunk_to_cstr(NODE_MEM(node), &node->as.literal);
 
   case CMARK_NODE_CODE_BLOCK:


### PR DESCRIPTION
In addition, fix a bug where the length of the literal value was calculated AFTER the actual literal string (null terminated) was allocated.

Before this fix:

```ruby
# footnote.string_content
"hi]: "
```

After this fix:

```ruby
# footnote.string_content
"hi"
```