### PR TITLE
Fix format specifier for printing a size_t

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -836,7 +836,7 @@ static void test_continuation_byte(test_batch_runner *runner,
 
     char *html =
         cmark_markdown_to_html(buf, strlen(buf), CMARK_OPT_VALIDATE_UTF8);
-    STR_EQ(runner, html, expected, "invalid utf8 continuation byte %d/%d", pos,
+    STR_EQ(runner, html, expected, "invalid utf8 continuation byte %zu/%zu", pos,
            len);
     free(html);
   }


### PR DESCRIPTION
`%d` is not the correct format specifier for `size_t`. I think `%zu` should be correct, provided that nobody is using an old compiler that doesn't support it. Based on [this stackoverflow question](https://stackoverflow.com/q/15610053) from 10 years ago, I think it should be ok.